### PR TITLE
Adhering to XR requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The quickstart guide for OnlineSubsystemPlayFab can be found at:
 
 |OSS version
 |-|
-|2.2.0
+|2.2.1
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -49,5 +49,3 @@ For games shipping to Xbox console and PC Game Pass program before September 202
 ## Known Limitations and Issues in the Current Preview Build
 
 - [General] Currently cross-play is only supported between Xbox consoles, PC Game Pass, Steam, and Switch.  Cross-play support between other platforms is coming soon.
-- [Xbox] Currently cannot use Xbox shell to send or receive platform level invites with PF OSS v2. This functionality will be supported in the generally available (GA) release.
-- [Xbox] Currently not fully integrated with Multiplayer Activity Service (Multiplayer activity is not always in-sync with user’s lobby state, user’s joinability is not populated correctly). This functionality will be supported in the generally available (GA) release.

--- a/Source/OnlineSubsystemPlayFab.Build.cs
+++ b/Source/OnlineSubsystemPlayFab.Build.cs
@@ -26,7 +26,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
     public OnlineSubsystemPlayFab(ReadOnlyTargetRules Target) : base(Target)
     {
         // We don't want to try and load when doing project gen, editor, server, etc
-        if (Target.bGenerateProjectFiles || (Target.Type != TargetType.Game && Target.Type != TargetType.Client))
+        if (Target.bGenerateProjectFiles)
         {
             PrecompileForTargets = PrecompileTargetsType.None;
             return;
@@ -203,10 +203,12 @@ public class OnlineSubsystemPlayFab : ModuleRules
             ThisModule.PublicDependencyModuleNames.Add("GDKCore");
             ThisModule.PublicDependencyModuleNames.Add("OnlineSubsystemGDK");
         }
+
         public void SetPlatformDefinitions(ModuleRules ThisModule)
         {
             ThisModule.PrivateDefinitions.Add("ONLINESUBSYSTEMGDK_PACKAGE=1");
         }
+
         public void ConfigurePlayFabDependencies(ReadOnlyTargetRules Target, ModuleRules ThisModule)
         {
             string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "GDK");
@@ -259,10 +261,12 @@ public class OnlineSubsystemPlayFab : ModuleRules
         {
             ThisModule.PublicDependencyModuleNames.Add("OnlineSubsystemSwitch");
         }
+
         public void SetPlatformDefinitions(ModuleRules ThisModule)
         {
             //No switch specific platform definitions.
         }
+
         public void ConfigurePlayFabDependencies(ReadOnlyTargetRules Target, ModuleRules ThisModule)
         {
             string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "Switch");
@@ -277,7 +281,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
             string MultiplayerDirectory = PlatformDirectories.Where(d => d.Contains("PlayFab.Multiplayer")).FirstOrDefault();
             string PartyDirectory = PlatformDirectories.Where(d => d.Contains("PlayFab.PlayFabParty")).FirstOrDefault();
             
-            if(String.IsNullOrWhiteSpace(MultiplayerDirectory) || String.IsNullOrWhiteSpace(PartyDirectory))
+            if (String.IsNullOrWhiteSpace(MultiplayerDirectory) || String.IsNullOrWhiteSpace(PartyDirectory))
             {
                 throw new BuildException("PlayFab Party precompiled dependencies were not found.");
             }
@@ -336,10 +340,12 @@ public class OnlineSubsystemPlayFab : ModuleRules
         {
             //No windows specific module dependencies.
         }
+
         public void SetPlatformDefinitions(ModuleRules ThisModule)
         {
             //No windows specific platform definitions.
         }
+
         public void ConfigurePlayFabDependencies(ReadOnlyTargetRules Target, ModuleRules ThisModule)
         {
             string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "Windows");

--- a/Source/Private/MatchmakingInterfacePlayFab.cpp
+++ b/Source/Private/MatchmakingInterfacePlayFab.cpp
@@ -131,7 +131,7 @@ bool FMatchmakingInterfacePlayFab::CreateMatchMakingTicket(const TArray< TShared
 	return true;
 }
 
-bool FMatchmakingInterfacePlayFab::CancelMatchmakingTicket(const PFEntityKey entity, const FName& SessionName)
+bool FMatchmakingInterfacePlayFab::CancelMatchmakingTicket(const FName& SessionName)
 {
 	FOnlineMatchmakingTicketInfoPtr MatchmakingTicketPtr;
 	if (!GetMatchmakingTicket(SessionName, MatchmakingTicketPtr) || !MatchmakingTicketPtr.IsValid())
@@ -297,6 +297,7 @@ void FMatchmakingInterfacePlayFab::OnMatchmakingStatusChanged(const FName Sessio
 				FNamedOnlineSessionRef NamedSession = SessionInterface->AddNamedSessionRef(SessionName, Ticket->SessionSettings);
 				NamedSession->HostingPlayerNum = INDEX_NONE;
 				NamedSession->OwningUserId = Ticket->SearchingPlayerNetId;
+				NamedSession->LocalOwnerId = Ticket->SearchingPlayerNetId;
 
 				OnJoinArrangedLobbyCompletedDelegate = FOnJoinArrangedLobbyCompletedDelegate::CreateRaw(this, &FMatchmakingInterfacePlayFab::OnJoinArrangedLobbyCompleted);
 				OnJoinArrangedLobbyCompleteDelegateHandle = OSSPlayFab->GetPlayFabLobbyInterface()->AddOnJoinArrangedLobbyCompletedDelegate_Handle(OnJoinArrangedLobbyCompletedDelegate);

--- a/Source/Private/MatchmakingInterfacePlayFab.h
+++ b/Source/Private/MatchmakingInterfacePlayFab.h
@@ -35,7 +35,7 @@ public:
 		FName SessionName, 
 		const FOnlineSessionSettings& NewSessionSettings, 
 		TSharedRef<FOnlineSessionSearch>& SearchSettings);
-	bool CancelMatchmakingTicket(const PFEntityKey entity, const FName& SessionName);
+	bool CancelMatchmakingTicket(const FName& SessionName);
 
 	void DoWork();
 

--- a/Source/Private/OnlineExternalUIInterfacePlayFab.h
+++ b/Source/Private/OnlineExternalUIInterfacePlayFab.h
@@ -28,6 +28,7 @@ private:
 	uint64_t InviteUIPreSelectedPlayers[c_PFInviteMaxPlayerCount] = {};
 	int32 LocalUserNumber;
 	FName SessionName;
+	FString ConnectionString;
 
 PACKAGE_SCOPE:
 
@@ -76,6 +77,7 @@ public:
 private:
 #if defined(OSS_PLAYFAB_WINGDK) || defined(OSS_PLAYFAB_XSX) || defined(OSS_PLAYFAB_XBOXONEGDK)
 	void ProcessShowPlayerPickerResults(TUniquePtr<XAsyncBlock> AsyncBlock);
+	bool SendGDKPlatformInvite(const TArray<uint64_t> & PlayersToInvite) const;
 #endif
 };
 

--- a/Source/Private/PlayFabLobby.h
+++ b/Source/Private/PlayFabLobby.h
@@ -112,6 +112,8 @@ private:
 	FOnlineSessionSearchResult CreateSearchResultFromLobby(const PFLobbySearchResult& Lobby);
 	bool IsSearchKey(const FString& Name);
 	FString ComposeLobbySearchQueryFilter(const FSearchParams& SearchParams);
+	void BuildSearchKeyMappingTable();
+	bool GetSearchKeyFromSettingMappingTable(const FString& SettingKey, FString& SearchKey, EOnlineKeyValuePairDataType::Type& Type) const;
 
 	// we can eliminate this map if we pass SessionName as asyncIdentifier to lobby calls
 	TMap<PFLobbyHandle, FName> LobbySessionMap;
@@ -136,6 +138,8 @@ private:
 		FOnUnregisterLocalPlayerCompleteDelegate UnregisterLocalPlayerCompleteDelegate;
 	};
 	FRemoveLocalPlayerData RemoveLocalPlayerData;
+
+	TMap<FString, TPair<FString, EOnlineKeyValuePairDataType::Type>> SearchKeyMappingTable;
 
 public:
 	void OnGetPlayFabIDsFromPlatformIDsCompleted(FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded, FPendingSendInviteData PendingSendInvite);

--- a/Source/Public/OnlineSubsystemPlayFab.h
+++ b/Source/Public/OnlineSubsystemPlayFab.h
@@ -109,7 +109,6 @@ public:
 	virtual IOnlineTimePtr GetTimeInterface() const override;
 	virtual IOnlineTitleFilePtr GetTitleFileInterface() const override;
 	virtual IOnlineEntitlementsPtr GetEntitlementsInterface() const override;
-	virtual IOnlineStorePtr GetStoreInterface() const override;
 	virtual IOnlineStoreV2Ptr GetStoreV2Interface() const override;
 	virtual IOnlinePurchasePtr GetPurchaseInterface() const override;
 	virtual IOnlineEventsPtr GetEventsInterface() const override;
@@ -157,8 +156,8 @@ public:
 	int32 MaxEndpointsPerDeviceCount = 1;
 	int32 MaxUserCount = 8;
 	int32 MaxUsersPerDeviceCount = 1;
-	PartyDirectPeerConnectivityOptions DirectPeerConnectivityOptions = PartyDirectPeerConnectivityOptions::AnyPlatformType |
-																	   PartyDirectPeerConnectivityOptions::AnyEntityLoginProvider;
+	PartyDirectPeerConnectivityOptions DirectPeerConnectivityOptions 
+		= PartyDirectPeerConnectivityOptions::AnyPlatformType | PartyDirectPeerConnectivityOptions::AnyEntityLoginProvider;
 
 	EPlayFabPartyNetworkState NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 	PartyNetwork* Network = nullptr;
@@ -257,7 +256,7 @@ public:
 	
 	PartyEndpoint* GetPartyEndpoint(uint32 EndpointId);
 
-	FString GetSandBox();
+	const FString GetSandBox() const;
 };
 
 namespace FNetworkProtocolTypes

--- a/Source/Public/OnlineSubsystemPlayFabTypes.h
+++ b/Source/Public/OnlineSubsystemPlayFabTypes.h
@@ -21,7 +21,7 @@ public:
 	 * Constructor
 	 */
 	FOnlineSessionInfoPlayFab()
-		: SessionId(FUniqueNetIdString())
+		: SessionId(FUniqueNetIdString::Create(TEXT(""), PLAYFAB_SUBSYSTEM))
 		, ConnectionString(FString())
 		, LobbyHandle(nullptr)
 		, SessionName(FName())
@@ -34,7 +34,7 @@ public:
 	 * @param InConnectionString lobby connection string
 	 */
 	FOnlineSessionInfoPlayFab(FString InConnectionString)
-		: SessionId(FUniqueNetIdString())
+		: SessionId(FUniqueNetIdString::Create(TEXT(""), PLAYFAB_SUBSYSTEM))
 		, ConnectionString(InConnectionString)
 		, LobbyHandle(nullptr)
 		, SessionName(FName())
@@ -48,7 +48,7 @@ public:
 	 * @param InConnectionString lobby connection string
 	 */
 	FOnlineSessionInfoPlayFab(FString LobbyId, FString InConnectionString)
-		: SessionId(FUniqueNetIdString(LobbyId))
+		: SessionId(FUniqueNetIdString::Create(LobbyId, PLAYFAB_SUBSYSTEM))
 		, ConnectionString(InConnectionString)
 		, LobbyHandle(nullptr)
 		, SessionName(FName())
@@ -63,8 +63,25 @@ public:
 	 * @param InSessionName
 	 */
 	FOnlineSessionInfoPlayFab(FString LobbyId, PFLobbyHandle InLobbyHandle, FName InSessionName)
-		: SessionId(FUniqueNetIdString(LobbyId))
+		: SessionId(FUniqueNetIdString::Create(LobbyId, PLAYFAB_SUBSYSTEM))
 		, ConnectionString(FString())
+		, LobbyHandle(InLobbyHandle)
+		, SessionName(InSessionName)
+	{
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param LobbyId The lobby associated with this session
+	 * @param InConnectionString lobby connection string
+	 * @param InLobbyHandle
+	 * @param InSessionName
+	 */
+	FOnlineSessionInfoPlayFab(FString LobbyId, FString InConnectionString,
+							  PFLobbyHandle InLobbyHandle, FName InSessionName)
+		: SessionId(FUniqueNetIdString::Create(LobbyId, PLAYFAB_SUBSYSTEM))
+		, ConnectionString(InConnectionString)
 		, LobbyHandle(InLobbyHandle)
 		, SessionName(InSessionName)
 	{
@@ -75,7 +92,7 @@ public:
 
 	virtual const FUniqueNetId& GetSessionId() const override
 	{
-		return SessionId;
+		return *SessionId;
 	}
 
 	virtual const uint8* GetBytes() const override
@@ -106,7 +123,7 @@ public:
 
 	void SetSessionId(FString InSessionId)
 	{
-		SessionId = FUniqueNetIdString(InSessionId);
+		SessionId = FUniqueNetIdString::Create(InSessionId, PLAYFAB_SUBSYSTEM);
 	}
 
 	void SetConnectionString(FString InConnectionString)
@@ -146,7 +163,7 @@ public:
 private:
 
 	/** Placeholder unique id */
-	FUniqueNetIdString SessionId;
+	FUniqueNetIdStringRef SessionId;
 	FString ConnectionString;
 	PFLobbyHandle LobbyHandle;
 	FName SessionName;
@@ -191,16 +208,6 @@ public:
 	 */
 	explicit FUniqueNetIdPlayFab(const FString& Str) :
 		UniqueNetId(FString(Str, 0).ToLower())
-	{
-	}
-
-	/**
-	 * Constructs this object with the specified net id
-	 *
-	 * @param InUniqueNetId the id to set ours to (assumed to be FUniqueNetIdPlayFab in fact)
-	 */
-	explicit FUniqueNetIdPlayFab(const FUniqueNetId& InUniqueNetId) :
-		UniqueNetId(*(FString*)InUniqueNetId.GetBytes())
 	{
 	}
 


### PR DESCRIPTION
- OSS now adheres to XR requirements 67 (Multiplayer Activities, Recent Players )and 124 (Platform Invites).
- Enabled support for GDK platform invites
- Enabled custom filtering
- Sandbox ID is now longer configured through a .ini, but it is read using XBL API

Tested with WinGDK, XSX and XboxOne