### PR TITLE
Additional includes required for compilation

### DIFF
--- a/Source/OnlineSubsystemPlayFab.Build.cs
+++ b/Source/OnlineSubsystemPlayFab.Build.cs
@@ -44,6 +44,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
         IPlayFabOSSPlatformConfigurator PlatformConfigurator = GetConfiguratorForPlatform(Platform);
 
         PublicDefinitions.Add("OSS_PLAYFAB_IS_PC=" + (PlatformConfigurator.IsPCPlatform(Target) ? "1" : "0"));
+        PrivateIncludePaths.Add(ModuleDirectory);
 
         PlatformConfigurator.AddModuleDependencies(this);
         PlatformConfigurator.SetPlatformDefinitions(this);

--- a/Source/Private/MatchmakingInterfacePlayFab.cpp
+++ b/Source/Private/MatchmakingInterfacePlayFab.cpp
@@ -4,8 +4,11 @@
 
 #include "MatchmakingInterfacePlayFab.h"
 #include "OnlineSubsystemPlayFab.h"
+#include "OnlineSubsystemPlayFabTypes.h"
 #include "OnlineSessionInterfacePlayFab.h"
 #include "OnlineIdentityInterfacePlayFab.h"
+#include "OnlineSubsystemPlayFabPrivate.h"
+#include "OnlineSubsystem.h"
 #include "PlayFabHelpers.h"
 #include "PlayFabUtils.h"
 

--- a/Source/Private/MatchmakingInterfacePlayFab.h
+++ b/Source/Private/MatchmakingInterfacePlayFab.h
@@ -6,6 +6,7 @@
 
 #include "OnlineDelegateMacros.h"
 #include "OnlineSubsystemPlayFabPackage.h"
+#include "OnlineSubsystemPlayFabTypes.h"
 #include "PlayFabLobby.h"
 
 THIRD_PARTY_INCLUDES_START

--- a/Source/Private/OnlineIdentityInterfacePlayFab.cpp
+++ b/Source/Private/OnlineIdentityInterfacePlayFab.cpp
@@ -4,6 +4,8 @@
 
 #include "OnlineIdentityInterfacePlayFab.h"
 #include "OnlineSubsystemPlayFab.h"
+#include "PlayFabHelpers.h"
+#include "PlayFabLobby.h"
 
 #include "Serialization/JsonWriter.h"
 #include "Serialization/JsonReader.h"

--- a/Source/Private/OnlineSessionInterfacePlayFab.h
+++ b/Source/Private/OnlineSessionInterfacePlayFab.h
@@ -8,6 +8,7 @@
 #include "OnlineSubsystemPlayFabDefines.h"
 #include "OnlineSubsystemPlayFabPackage.h"
 #include "OnlineSubsystemPlayFabTypes.h"
+#include "OnlineVoiceInterfacePlayFab.h"
 #include "PlayFabLobby.h"
 #include "MatchmakingInterfacePlayFab.h"
 

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -4,6 +4,7 @@
 
 #include "OnlineSubsystemPlayFab.h"
 #include "OnlineIdentityInterfacePlayFab.h"
+#include "OnlineExternalUIInterfacePlayFab.h"
 #include "PlayFabSocketSubsystem.h"
 #include "Interfaces/IPluginManager.h"
 #include "SocketSubsystem.h"

--- a/Source/Private/PlayFabEventTracer.cpp
+++ b/Source/Private/PlayFabEventTracer.cpp
@@ -13,6 +13,9 @@
 #include "Misc/EngineVersion.h"
 #include "Misc/NetworkVersion.h"
 
+#include "OnlineSubsystemPlayFab.h"
+#include "OnlineIdentityInterfacePlayFab.h"
+
 #if defined(OSS_PLAYFAB_WINGDK) || defined(OSS_PLAYFAB_XSX) || defined(OSS_PLAYFAB_XBOXONEGDK)
 #include "grdk.h"
 #endif

--- a/Source/Private/PlayFabEventTracer.h
+++ b/Source/Private/PlayFabEventTracer.h
@@ -3,6 +3,9 @@
 //--------------------------------------------------------------------------------------
 
 #pragma once
+#include "CoreMinimal.h"
+#include "OnlineSubsystemPackage.h"
+#include "Dom/JsonObject.h"
 
 THIRD_PARTY_INCLUDES_START
 #include <PFEntityKey.h>

--- a/Source/Private/PlayFabHelpers.cpp
+++ b/Source/Private/PlayFabHelpers.cpp
@@ -1,6 +1,11 @@
 #include "PlayFabHelpers.h"
 
 #include "GenericPlatform/GenericPlatformMisc.h"
+#include "HttpModule.h"
+#include "OnlineSubsystem.h"
+#include "Interfaces/IHttpResponse.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
 
 bool
 MakePlayFabRestRequest(

--- a/Source/Private/PlayFabHelpers.h
+++ b/Source/Private/PlayFabHelpers.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "CoreMinimal.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Dom/JsonObject.h"
+
 namespace API
 {
 	// The name of the token parameter expected by the PlayFab login API.

--- a/Source/Private/PlayFabLobby.cpp
+++ b/Source/Private/PlayFabLobby.cpp
@@ -4,7 +4,14 @@
 
 #include "PlayFabLobby.h"
 #include "PlayFabUtils.h"
+#include "PlayFabHelpers.h"
 #include "OnlineSubsystemPlayFab.h"
+#include "OnlineSessionInterfacePlayFab.h"
+#include "OnlineSessionSettings.h"
+#include "OnlineSubsystem.h"
+#include "OnlineSubsystemPlayFabPrivate.h"
+#include "OnlineSubsystemSessionSettings.h"
+
 
 static struct FSearchKeyMappingTable
 {

--- a/Source/Private/PlayFabLobby.h
+++ b/Source/Private/PlayFabLobby.h
@@ -6,7 +6,11 @@
 
 #include "OnlineDelegateMacros.h"
 #include "OnlineSubsystemPlayFabPackage.h"
+#include "OnlineSubsystemPlayFabTypes.h"
 #include "Interfaces/OnlineSessionInterface.h"
+
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
 
 THIRD_PARTY_INCLUDES_START
 #ifdef OSS_PLAYFAB_SWITCH
@@ -49,6 +53,8 @@ typedef FOnInvitationReceived::FDelegate FOnInvitationReceivedDelegate;
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnLobbyDisconnected, FName);
 typedef FOnLobbyDisconnected::FDelegate FOnLobbyDisconnectedDelegate;
+
+class FPlayFabUser;
 
 class FPlayFabLobby
 {

--- a/Source/Public/OnlineSubsystemPlayFabTypes.h
+++ b/Source/Public/OnlineSubsystemPlayFabTypes.h
@@ -4,10 +4,16 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
+#include "OnlineIdentityInterfacePlayFab.h"
+#include "OnlineSessionSettings.h"
+#include "OnlineSubsystemTypes.h"
+
 THIRD_PARTY_INCLUDES_START
 #include <PFEntityKey.h>
 #include <PFMultiplayer.h>
-#include <PFMatchmaking.h> 
+#include <PFMatchmaking.h>
+#include <PFLobby.h>
 THIRD_PARTY_INCLUDES_END
 
 #include "Runtime/Launch/Resources/Version.h"


### PR DESCRIPTION
Compilation fails initially when installing the plugin due to the following missing headers. Everything works as expected once these have been added.