### PR TITLE
Don't set the PlayFab socket subsystem to default as it will break an…

### DIFF
--- a/Source/Private/PlayFabSocketSubsystem.cpp
+++ b/Source/Private/PlayFabSocketSubsystem.cpp
@@ -22,7 +22,7 @@ FName CreatePlayFabSocketSubsystem()
 	if (SocketSubsystem->Init(Error))
 	{
 		FSocketSubsystemModule& SSS = FModuleManager::LoadModuleChecked<FSocketSubsystemModule>("Sockets");
-		SSS.RegisterSocketSubsystem(SubsystemName, SocketSubsystem, true);
+		SSS.RegisterSocketSubsystem(SubsystemName, SocketSubsystem, false);
 		return SubsystemName;
 	}
 	else


### PR DESCRIPTION
…y functionality requiring non-PlayFab sockets (such as connecting to a dedicated server)

All PlayFab calls to the socket subsystem use the PLAYFAB_SOCKET_SUBSYSTEM define anyway so this doesn't affect any PlayFab logic