### PR TITLE
Release PF OSS 2.2.5 version

### DIFF
--- a/OnlineSubsystemPlayFab.uplugin
+++ b/OnlineSubsystemPlayFab.uplugin
@@ -1,8 +1,8 @@
 {
 	"FileVersion" : 3,
     "FriendlyName": "Online Subsystem PlayFab Party & Multiplayer",
-	"Version": 2.24,
-	"VersionName": "2.2.4",
+	"Version": 2.25,
+	"VersionName": "2.2.5",
 	"Description": "Support for the PlayFab Party and Multiplayer platform",
 	"Category": "Networking",
 	"CreatedBy": "Microsoft Corporation",

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ The quickstart guide for OnlineSubsystemPlayFab can be found at:
 |Unreal Engine version|4.27|
 |-|-|
 Multiplayer SDK|v1.1.5+
-Platforms|GDK (June 2021), Win64+Steam, Nintendo Switch, Sony PlayStation4/PlayStation5
+Platforms|GDK (June 2021), Win64+Steam, Nintendo Switch, Sony PS4™/PS5™
 
 |Unreal Engine version|5.0|
 |-|-|
 Multiplayer SDK|v1.1.5+
-Platforms|GDK (October 2021, Update 5), Win64+Steam
+Platforms|GDK (October 2021, Update 5), Win64+Steam, Nintendo Switch, Sony PS4™/PS5™
 
 ## Important Note
 
-The PlayFab Online Subsystem (PF OSS) v2 is currently generally available (GA) for GDK and Win64+Steam and Nintendo Switch.
+The PlayFab Online Subsystem (PF OSS) v2 is currently generally available (GA) for GDK and Win64+Steam, Nintendo Switch, and Sony PS4™/PS5™.
 
 For platform certification and shipping to retail users, games must use the generally available (GA) release of the SDKs and engine plugins that will become available in the coming months.
 
@@ -55,4 +55,8 @@ For games shipping to Xbox console and PC Game Pass program before September 202
 
 ## Known Limitations and Issues in the Current Preview Build
 
-- [General] Currently cross-play is only supported between Xbox consoles, PC Game Pass, Steam, and Switch.  Cross-play support between other platforms is coming soon.
+- [General] Currently cross-play is only supported between Xbox consoles, PC Game Pass, Steam, Switch, and Sony PS4™/PS5™.  Cross-play support between other platforms is coming soon.
+
+"PlayStation" is a registered trademark or trademark of Sony Interactive Entertainment Inc.
+"PS4" is a registered trademark or trademark of Sony Interactive Entertainment Inc.
+"PS5" is a registered trademark or trademark of Sony Interactive Entertainment Inc.

--- a/SetUpPrivateOSS.ps1
+++ b/SetUpPrivateOSS.ps1
@@ -33,5 +33,5 @@ if ($Platform -like "PlayStation")
 	git submodule update --recursive --init Source/PlatformSpecific/PlayStation
 
 	Write-Host "Patching PlayStation platforms patch..."
-	git apply --quiet Source/PlatformSpecific/PlayStation/playstation.patch
+	git apply --reject --whitespace=fix Source/PlatformSpecific/PlayStation/playstation.patch
 }

--- a/Source/OnlineSubsystemPlayFab.Build.cs
+++ b/Source/OnlineSubsystemPlayFab.Build.cs
@@ -352,18 +352,13 @@ public class OnlineSubsystemPlayFab : ModuleRules
             }        
 
             // Find the MLP and Party library names under the PlatformDir.
-            string[] PlatformDirectories = System.IO.Directory.GetDirectories(PlatformDir);
-            string MultiplayerDirectory = PlatformDirectories.Where(d => d.Contains("PlayFab.Multiplayer")).FirstOrDefault();
-            string PartyDirectory = PlatformDirectories.Where(d => d.Contains("PlayFab.PlayFabParty")).FirstOrDefault();
-            
-            if (String.IsNullOrWhiteSpace(MultiplayerDirectory) || String.IsNullOrWhiteSpace(PartyDirectory))
-            {
-                throw new BuildException("PlayFab Party precompiled dependencies were not found.");
-            }
+            NuGetPackageLoader NuGetLoader = new NuGetPackageLoader();
+            NuGetPackageLoader.NuGetPackageInformation NugetPackageInfo = new NuGetPackageLoader.NuGetPackageInformation();
+            NuGetLoader.ParsingNuGetPackage(ref PlatformDir, ref NugetPackageInfo);
 
             // Load Party binaries.
-            string PartyIncludePath = Path.Combine(PartyDirectory, "build", "native", "include");
-            string PartyLibraryPath = Path.Combine(PartyDirectory, "build", "native", "lib", "NX64", "release");
+            string PartyIncludePath = Path.Combine(PlatformDir, NugetPackageInfo.PartyPackagePath, "build", "native", "include");
+            string PartyLibraryPath = Path.Combine(PlatformDir, NugetPackageInfo.PartyPackagePath, "build", "native", "lib", "NX64", "release");
 
             if (!Directory.Exists(PartyIncludePath) ||
                 !Directory.Exists(PartyLibraryPath))
@@ -377,8 +372,8 @@ public class OnlineSubsystemPlayFab : ModuleRules
             ThisModule.RuntimeDependencies.Add("$(TargetOutputDir)/Party.nrr", Path.Combine(PartyLibraryPath, "Party.nrr"), StagedFileType.DebugNonUFS);
 
             // Load Multiplayer binaries
-            string MultiplayerIncludePath = Path.Combine(MultiplayerDirectory, "build", "native", "include");
-            string MultiplayerLibraryPath = Path.Combine(MultiplayerDirectory, "build", "native", "lib", "NX64", "release");
+            string MultiplayerIncludePath = Path.Combine(PlatformDir, NugetPackageInfo.MultiplayerPackagePath, "build", "native", "include");
+            string MultiplayerLibraryPath = Path.Combine(PlatformDir, NugetPackageInfo.MultiplayerPackagePath, "build", "native", "lib", "NX64", "release");
 
             if (!Directory.Exists(MultiplayerIncludePath) ||
                 !Directory.Exists(MultiplayerLibraryPath))

--- a/Source/Private/PlayFabLobby.h
+++ b/Source/Private/PlayFabLobby.h
@@ -89,6 +89,8 @@ public:
 	void HandleInviteListenerStatusChanged(const PFLobbyInviteListenerStatusChangedStateChange& StateChange);
 	void HandleInvitationReceived(const PFLobbyInviteReceivedStateChange& StateChange);
 	void HandleLobbyDisconnected(const PFLobbyDisconnectedStateChange& StateChange);
+	void HandleLobbyDisconnecting(const PFLobbyDisconnectingStateChange& StateChange);
+	void HandleForceRemoveMember(const PFLobbyForceRemoveMemberCompletedStateChange& StateChange);
 
 PACKAGE_SCOPE:
 	DEFINE_ONLINE_DELEGATE_TWO_PARAM(OnLobbyCreatedAndJoinCompleted, bool, FName);

--- a/Source/Public/OnlineSubsystemPlayFabTypes.h
+++ b/Source/Public/OnlineSubsystemPlayFabTypes.h
@@ -323,7 +323,7 @@ public:
 
 	friend FORCEINLINE uint32 GetTypeHash(const FUniqueNetIdPlayFab& Id)
 	{
-		return GetTypeHash(Id.UniqueNetId);
+		return ::GetTypeHash(Id.UniqueNetId);
 	}
 
 	friend FArchive& operator<<(FArchive& Ar, FUniqueNetIdPlayFab& UserId)


### PR DESCRIPTION
This 2.2.5 version has minor bug fixes.
1. Add missing state handler on MLP.
2. Fix build error on UE5.0.

And this PR tested cross-play for all platforms.
So, we are support UE5 for Switch and PlayStation officially now.
