### PR TITLE
Fix compile error in UE 5.2

### DIFF
--- a/Source/Private/IPAddressPlayFab.cpp
+++ b/Source/Private/IPAddressPlayFab.cpp
@@ -132,8 +132,11 @@ TSharedRef<FInternetAddr> FInternetAddrPlayFab::Clone() const
 
 uint32 FInternetAddrPlayFab::GetConstTypeHash() const
 {
-	//return ::GetTypeHash(Id.UniqueNetId);
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	return GetTypeHashHelper(ToString(true));
+#else
+	return ::GetTypeHash(ToString(true));
+#endif
 }
 
 bool FInternetAddrPlayFab::operator!=(const FInternetAddrPlayFab& Other) const

--- a/Source/Private/IPAddressPlayFab.cpp
+++ b/Source/Private/IPAddressPlayFab.cpp
@@ -132,7 +132,8 @@ TSharedRef<FInternetAddr> FInternetAddrPlayFab::Clone() const
 
 uint32 FInternetAddrPlayFab::GetConstTypeHash() const
 {
-	return ::GetTypeHash(ToString(true));
+	//return ::GetTypeHash(Id.UniqueNetId);
+	return GetTypeHashHelper(ToString(true));
 }
 
 bool FInternetAddrPlayFab::operator!=(const FInternetAddrPlayFab& Other) const

--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -1040,9 +1040,9 @@ void FOnlineSessionPlayFab::OnLobbyUpdate(FName SessionName, const PFLobbyUpdate
 	}
 	#endif // OSS_PLAYFAB_WINGDK || OSS_PLAYFAB_XSX || OSS_PLAYFAB_XBOXONEGDK
 
-	/* Deprecated delegate was removed
+#if ENGINE_MAJOR_VERSION < 5 || (ENGINE_MAJOR_VERSION == 5  && ENGINE_MINOR_VERSION < 2)
 	TriggerOnSessionCustomDataChangedDelegates(SessionName, ExistingNamedSession->SessionSettings);
-	*/
+#endif
 }
 
 void FOnlineSessionPlayFab::OnLobbyMemberAdded(FName SessionName, const PFLobbyMemberAddedStateChange& StateChange)

--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -1040,7 +1040,9 @@ void FOnlineSessionPlayFab::OnLobbyUpdate(FName SessionName, const PFLobbyUpdate
 	}
 	#endif // OSS_PLAYFAB_WINGDK || OSS_PLAYFAB_XSX || OSS_PLAYFAB_XBOXONEGDK
 
+	/* Deprecated delegate was removed
 	TriggerOnSessionCustomDataChangedDelegates(SessionName, ExistingNamedSession->SessionSettings);
+	*/
 }
 
 void FOnlineSessionPlayFab::OnLobbyMemberAdded(FName SessionName, const PFLobbyMemberAddedStateChange& StateChange)

--- a/Source/Private/PlayFabLobby.cpp
+++ b/Source/Private/PlayFabLobby.cpp
@@ -5,6 +5,7 @@
 #include "PlayFabLobby.h"
 #include "PlayFabUtils.h"
 #include "OnlineSubsystemPlayFab.h"
+#include "Online/OnlineSessionNames.h"
 
 static struct FSearchKeyMappingTable
 {

--- a/Source/Public/OnlineSubsystemPlayFabTypes.h
+++ b/Source/Public/OnlineSubsystemPlayFabTypes.h
@@ -323,7 +323,8 @@ public:
 
 	friend FORCEINLINE uint32 GetTypeHash(const FUniqueNetIdPlayFab& Id)
 	{
-		return ::GetTypeHash(Id.UniqueNetId);
+		//return ::GetTypeHash(Id.UniqueNetId);
+		return GetTypeHashHelper(Id.UniqueNetId);
 	}
 
 	friend FArchive& operator<<(FArchive& Ar, FUniqueNetIdPlayFab& UserId)

--- a/Source/Public/OnlineSubsystemPlayFabTypes.h
+++ b/Source/Public/OnlineSubsystemPlayFabTypes.h
@@ -323,8 +323,11 @@ public:
 
 	friend FORCEINLINE uint32 GetTypeHash(const FUniqueNetIdPlayFab& Id)
 	{
-		//return ::GetTypeHash(Id.UniqueNetId);
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 		return GetTypeHashHelper(Id.UniqueNetId);
+#else
+		return ::GetTypeHash(Id.UniqueNetId);
+#endif
 	}
 
 	friend FArchive& operator<<(FArchive& Ar, FUniqueNetIdPlayFab& UserId)


### PR DESCRIPTION
- Ignore to trigger deprecated delegate in 5.2 ( OnSessionCustomDataChanged )
- Use GetTypeHashHelper since GetTypeHash was moved to hidden friend
ref: https://github.com/EpicGames/UnrealEngine/commit/6f488a9e07260936b2d770bd97cbd181ba0b0da7