### PR TITLE
[Bug+Feat] Fix CPP20 Deprecation Bug + Allow Dynamic Project Location

### DIFF
--- a/Source/OnlineSubsystemPlayFab.Build.cs
+++ b/Source/OnlineSubsystemPlayFab.Build.cs
@@ -217,7 +217,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
 			
 		PrivateDefinitions.Add("ONLINESUBSYSTEMGDK_PACKAGE=1");
         
-        string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "GDK");
+        string PlatformDir = Path.Combine(ModuleDirectory,  "..", "Platforms", "GDK");
 
         if (!Directory.Exists(PlatformDir) ||
             !Directory.Exists(Path.Combine(PlatformDir, "Redist")) ||
@@ -260,7 +260,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
 	{
 		PublicDependencyModuleNames.Add("OnlineSubsystemSwitch");
         
-        string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "Switch");
+        string PlatformDir = Path.Combine(ModuleDirectory,  "..", "Platforms", "Switch");
 
         if (!Directory.Exists(PlatformDir))
         {
@@ -320,7 +320,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
 		PublicDefinitions.Add("OSS_PLAYFAB_IS_PC=1");
 		PublicDefinitions.Add("USES_NATIVE_SESSION=1");
 
-		string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "Windows");
+		string PlatformDir = Path.Combine(ModuleDirectory,  "..", "Platforms", "Windows");
 
         if (!Directory.Exists(PlatformDir) || 
             !Directory.Exists(Path.Combine(PlatformDir, "Redist")) || 
@@ -350,7 +350,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
 	{
 		NuGetPackageLoader.NuGetPackageInformation NugetPackageInfo = new NuGetPackageLoader.NuGetPackageInformation();
 		NuGetPackageLoader NuGetLoader = new NuGetPackageLoader();
-		string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "PS4");
+		string PlatformDir = Path.Combine(ModuleDirectory,  "..", "Platforms", "PS4");
 		NuGetLoader.ParsingNuGetPackage(ref PlatformDir, ref NugetPackageInfo);
 
 		PublicDependencyModuleNames.Add("OnlineSubsystemPS4");
@@ -365,7 +365,7 @@ public class OnlineSubsystemPlayFab : ModuleRules
     {
 		NuGetPackageLoader.NuGetPackageInformation NugetPackageInfo = new NuGetPackageLoader.NuGetPackageInformation();
 		NuGetPackageLoader NuGetLoader = new NuGetPackageLoader();
-        string PlatformDir = Path.Combine(Directory.GetCurrentDirectory(), "..", "Plugins", "Online", "OnlineSubsystemPlayFab", "Platforms", "PS5");
+        string PlatformDir = Path.Combine(ModuleDirectory,  "..", "Platforms", "PS5");
         NuGetLoader.ParsingNuGetPackage(ref PlatformDir, ref NugetPackageInfo);
     
         PublicDependencyModuleNames.Add("OnlineSubsystemPS5");

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -1286,7 +1286,7 @@ void FOnlineSubsystemPlayFab::OnEndpointDestroyed(const PartyStateChange* Change
 				TSharedRef<FInternetAddr> CompareAddr = SocketSubsystem->CreateInternetAddr();
 				CompareAddr->SetIp(EndpointId);
 				CompareAddr->SetPort(EndpointId);
-				UNetConnection** ConnectionFound = PlayFabNetDriver->MappedClientConnections.Find(CompareAddr);
+				auto ConnectionFound = PlayFabNetDriver->MappedClientConnections.Find(CompareAddr);
 				if (ConnectionFound != nullptr)
 				{
 					ConnectionToClose = *ConnectionFound;

--- a/Source/Private/PlayFabLobby.cpp
+++ b/Source/Private/PlayFabLobby.cpp
@@ -1767,7 +1767,7 @@ void FPlayFabLobby::OnGetPlayFabIDsFromPlatformIDsCompleted(FHttpRequestPtr Http
 		return;
 	}
 
-	auto OnGetPlayerCombinedInfoRequestCompleted = TDelegate<void(FHttpRequestPtr, FHttpResponsePtr, bool)>::CreateLambda([=](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
+	auto OnGetPlayerCombinedInfoRequestCompleted = TDelegate<void(FHttpRequestPtr, FHttpResponsePtr, bool)>::CreateLambda([=, this](FHttpRequestPtr HttpRequest, FHttpResponsePtr HttpResponse, bool bSucceeded)
 	{
 		if (HttpResponse == nullptr || HttpResponse->GetResponseCode() != 200)
 		{


### PR DESCRIPTION
This pull request is 2 parts. 
Part 1 Fixes the current bug when using UE 5.3 with CPP20 because of the deprecation of implicit this in the std library for [=].
Reference: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0806r2.html

Part 2 Fixes the requirement of installing the plugin in the engine source by changing the logic from `Directory.GetCurrentDirectory()` to using `ModuleDirectory`.