### PR TITLE
Fix mute functions

### DIFF
--- a/Source/Private/OnlineVoiceInterfacePlayFab.cpp
+++ b/Source/Private/OnlineVoiceInterfacePlayFab.cpp
@@ -453,17 +453,18 @@ bool FOnlineVoicePlayFab::IsRemotePlayerTalking(const FUniqueNetId& UniqueId)
 bool FOnlineVoicePlayFab::IsMuted(uint32 LocalUserNum, const FUniqueNetId& UniqueId) const
 {
 	const FLocalTalkerPlayFab* LocalTalker = GetLocalTalker(LocalUserNum);
-	if (LocalTalker)
+	const FRemoteTalkerPlayFab* RemoteTalker = GetRemoteTalker(UniqueId);
+	if (LocalTalker && RemoteTalker)
 	{
 		PartyBool InputMuted;
-		PartyError Err = LocalTalker->GetChatControl()->GetAudioInputMuted(&InputMuted);
+		PartyError Err = LocalTalker->GetChatControl()->GetIncomingAudioMuted(RemoteTalker->GetChatControl(), &InputMuted);
 		if (PARTY_SUCCEEDED(Err))
 		{
 			return static_cast<bool>(InputMuted);
 		}
 		else
 		{
-			UE_LOG_ONLINE(Error, TEXT("GetAudioInputMuted failed: %s"), *GetPartyErrorMessage(Err));
+			UE_LOG_ONLINE(Error, TEXT("GetIncomingAudioMuted failed: %s"), *GetPartyErrorMessage(Err));
 		}
 	}
 

--- a/Source/Private/OnlineVoiceInterfacePlayFab.cpp
+++ b/Source/Private/OnlineVoiceInterfacePlayFab.cpp
@@ -71,10 +71,13 @@ const FLocalTalkerPlayFab* FOnlineVoicePlayFab::GetLocalTalker(const int32 Local
 const FRemoteTalkerPlayFab* FOnlineVoicePlayFab::GetRemoteTalker(const FUniqueNetId& UniqueId) const
 {
 	const FString& PlatformId = UniqueId.ToString();
-	if (LocalTalkers.Contains(PlatformId))
+	for (auto& RemoteTalkerKvPair : RemoteTalkers)
 	{
-		const FRemoteTalkerPlayFab& PartyLocalTalker = RemoteTalkers[PlatformId];
-		return &PartyLocalTalker;
+		const FRemoteTalkerPlayFab& RemoteTalker = RemoteTalkerKvPair.Value;
+		if (RemoteTalker.GetPlatformUserId() == PlatformId)
+		{
+			return &RemoteTalker;
+		}
 	}
 
 	return nullptr;


### PR DESCRIPTION
We fixed two issues here:

- `GetRemoteTalker` is currently checking if the remote user exists in the `LocalTalkers` map. Instead we search in the `RemoteTalkers` map. We do it this way because, according to the comment, "Key here is a PlayFab Entity ID, if you want the platform ID, access the FRemoteTalkerPlayFab member var". It was preventing the `MuteRemoteTalker` function to work properly.
- `IsMuted` only works for local talkers at the moment. `UniqueId` parameter is ignored. We have checked other OSS and it seems they only work for remote talkers (which makes more sense, right?). So we implemented it in the same way.
