### PR TITLE
Set BuildUniqueId in SessionSettings

### DIFF
--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -254,6 +254,9 @@ bool FOnlineSessionPlayFab::InternalCreateSession(const FUniqueNetId& HostingPla
 	Session->LocalOwnerId = HostingPlayerId.AsShared();
 	Session->SessionInfo = NewSessionInfo;
 
+	// Unique identifier of this build for compatibility
+	Session->SessionSettings.BuildUniqueId = GetBuildUniqueId();
+
 	if (!OSSPlayFab)
 	{
 		return false;


### PR DESCRIPTION
All major OSS do this. Also this is needed for invitations, at least on Steam which is checking `BuildUniqueId` in `FillSessionFromLobbyData`.