### PR TITLE
Add missing ONLINESUBSYSTEMPLAYFAB_API

### DIFF
--- a/Source/Public/OnlineCognitiveServicesInterfacePlayFab.h
+++ b/Source/Public/OnlineCognitiveServicesInterfacePlayFab.h
@@ -25,7 +25,7 @@ typedef FOnPlayFabChatTextReceived::FDelegate FOnPlayFabChatTextReceivedDelegate
 DECLARE_MULTICAST_DELEGATE_FourParams(FOnPlayFabVoiceChatTranscriptionReceived, TSharedRef<const FUniqueNetId> /*Sender*/, EVoiceChatTranscriptionSource /*SourceType*/, bool /*bFinalTranscription*/, const FString& /*TranscriptionText*/);
 typedef FOnPlayFabVoiceChatTranscriptionReceived::FDelegate FOnPlayFabVoiceChatTranscriptionReceivedDelegate;
 
-class FOnlineCognitiveServicesPlayFab
+class ONLINESUBSYSTEMPLAYFAB_API FOnlineCognitiveServicesPlayFab
 	: public TSharedFromThis<FOnlineCognitiveServicesPlayFab, ESPMode::ThreadSafe>
 {
 PACKAGE_SCOPE:

--- a/Source/Public/OnlineIdentityInterfacePlayFab.h
+++ b/Source/Public/OnlineIdentityInterfacePlayFab.h
@@ -64,7 +64,7 @@ private:
 	FDateTime EntityTokenUpdateTime;
 };
 
-class FOnlineIdentityPlayFab
+class ONLINESUBSYSTEMPLAYFAB_API FOnlineIdentityPlayFab
 	: public IOnlineIdentity
 	, public TSharedFromThis<FOnlineIdentityPlayFab, ESPMode::ThreadSafe>
 {

--- a/Source/Public/OnlineVoiceInterfacePlayFab.h
+++ b/Source/Public/OnlineVoiceInterfacePlayFab.h
@@ -105,7 +105,7 @@ private:
 	PartyChatControl* ChatControl = nullptr;
 };
 
-class FOnlineVoicePlayFab
+class ONLINESUBSYSTEMPLAYFAB_API FOnlineVoicePlayFab
 	: public IOnlineVoice
 	, public TSharedFromThis<FOnlineVoicePlayFab, ESPMode::ThreadSafe>
 {


### PR DESCRIPTION
Interfaces defined in Public headers are meant to be used from games, but they they won't link properly (at least in Editor) without those fixes.