### PR TITLE
Use WebAPI ticket for Steam auth

### DIFF
--- a/Source/PlatformSpecific/ApplyHTTPRequestHeaders.Win.cpp
+++ b/Source/PlatformSpecific/ApplyHTTPRequestHeaders.Win.cpp
@@ -28,6 +28,37 @@ bool FOnlineIdentityPlayFab::ApplyPlatformHTTPRequestData(const FString& Platfor
 {
     IOnlineSubsystem* NativeSubsystem = IOnlineSubsystem::GetByPlatform();
     bool headersApplied = false;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 4
+    if (NativeSubsystem)
+    {
+        IOnlineIdentityPtr NativeIdentityInterface = NativeSubsystem->GetIdentityInterface();
+        if (NativeIdentityInterface && NativeIdentityInterface.IsValid())
+        {
+            FOnGetLinkedAccountAuthTokenCompleteDelegate Delegate = FOnGetLinkedAccountAuthTokenCompleteDelegate::CreateLambda(
+            [this, InPlatformUserID = PlatformUserID](int32 LocalUserNum, bool bWasSuccessful, const FExternalAuthToken& AuthToken)
+            {
+                if (bWasSuccessful && AuthToken.HasTokenString())
+                {
+                    TSharedPtr<FJsonObject> RequestBodyJson;
+                    RequestBodyJson = MakeShareable(new FJsonObject());
+                    RequestBodyJson->SetStringField(TEXT("SteamTicket"), AuthToken.TokenString);
+                    RequestBodyJson->SetBoolField(TEXT("TicketIsServiceSpecific"), true);
+
+                    UserAuthRequestData MetaData;
+                    UserAuthRequestsInFlight.Add(InPlatformUserID, MetaData);
+
+                    FOnlineIdentityPlayFab::OnPopulatePlatformRequestDataCompleted(true, InPlatformUserID, TMap<FString, FString>(), RequestBodyJson);
+                }
+                else
+                {
+                    FOnlineIdentityPlayFab::OnPopulatePlatformRequestDataCompleted(false, InPlatformUserID, TMap<FString, FString>(), nullptr);
+                }
+            });
+            NativeIdentityInterface->GetLinkedAccountAuthToken(0, TEXT("WebAPI:AzurePlayFab"), Delegate);
+            headersApplied = true;
+        }
+    }
+#else
     TSharedPtr<FJsonObject> RequestBodyJson;
     if (NativeSubsystem)
     {


### PR DESCRIPTION
Valve recommends using `GetAuthTicketForWebApi` (added in SDK 1.57) instead of `GetAuthSessionTicket` for auth.

Epic added SDK 1.57 in UE 5.4 and added support this new API at the same time.