### PR TITLE
Fix init when steam is not running

### DIFF
--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -63,7 +63,10 @@ bool FOnlineSubsystemPlayFab::Init()
 	UE_LOG_ONLINE(Verbose, TEXT("FOnlineSubsystemPlayFab::Init"));
 	
 	NativeOSS = IOnlineSubsystem::GetByPlatform();
-	check(NativeOSS);
+	if (!ensure(NativeOSS))
+	{
+		return false;
+	}
 
 #ifdef OSS_PLAYFAB_PLAYSTATION
 	OnlineAsyncTaskThreadRunnable = new FOnlineAsyncTaskManagerPlayFab(this);


### PR DESCRIPTION
When starting the game with Steam closed the Steam OSS can't initialize and the Null OSS is initialized instead.

In this case, the `check` was crashing our game in Dev/Test. In Shipping the game was starting correctly but it wasn't working because auth was not implemented in the Null OSS.

Returning false when the Native OSS is not available seems like a better option here. Alternatively we could just remove the `check`?