### PR TITLE
Access policy fixes

### DIFF
--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -1080,14 +1080,7 @@ void FOnlineSessionPlayFab::OnLobbyUpdate(FName SessionName, const PFLobbyUpdate
 		if (SUCCEEDED(Hr))
 		{
 			UE_LOG_ONLINE_SESSION(Verbose, TEXT("FOnlineSessionPlayFab::OnLobbyUpdate access policy updated to :%u"), NewAccessPolicy);
-			if (NewAccessPolicy == PFLobbyAccessPolicy::Public)
-			{
-				ExistingNamedSession->SessionSettings.bShouldAdvertise = true;
-			}
-			else //(NewAccessPolicy == PFLobbyAccessPolicy::Private) || (NewAccessPolicy == PFLobbyAccessPolicy::Friends)
-			{
-				ExistingNamedSession->SessionSettings.bShouldAdvertise = false;
-			}
+			ExistingNamedSession->SessionSettings.bShouldAdvertise = (NewAccessPolicy != PFLobbyAccessPolicy::Private);
 		}
 		else
 		{


### PR DESCRIPTION
`UpdateSession` does not update `accessPolicy` which does not allow us to change session visibility from the in-game.

Also `accessPolicy` is not set correctly after matchmaking, preventing sessions from being found when calling `FindSessions`. In a similar way the `maxMemberCount` is not set correctly. We suggest using the values the session settings that was passed at the time `StartMatchmaking` was called.
