### PR TITLE
Surface PlayFab lobby invites through OnSessionUserInviteAccepted

### DIFF
--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -2340,6 +2340,19 @@ void FOnlineSessionPlayFab::OnInvitationReceived_PlayFabMultiplayer(const PFEnti
 	TriggerOnPlayFabMultiplayerInviteReceivedDelegates(ListeningEntityKey, InvitingEntityKey, InConnectionString);
 }
 
+void FOnlineSessionPlayFab::NotifyLobbyInviteForStandardDelegate_PlayFabMultiplayer(const PFLobbyInviteReceivedStateChange& StateChange)
+{
+	FOnlineSessionSearchResult SearchResult = CreateSearchResultFromInvite(StateChange);
+
+	const int32 ControllerIndex = 0;
+	FOnlineIdentityPlayFabPtr PlayFabIdentityInt = OSSPlayFab ? OSSPlayFab->GetIdentityInterfacePlayFab() : nullptr;
+	TSharedPtr<const FUniqueNetId> LocalUniqueId = (PlayFabIdentityInt.IsValid() && PlayFabIdentityInt->GetAllPartyLocalUsers().Num() > 0)
+		? PlayFabIdentityInt->GetUniquePlayerId(ControllerIndex)
+		: nullptr;
+
+	TriggerOnSessionUserInviteAcceptedDelegates(LocalUniqueId.IsValid(), ControllerIndex, LocalUniqueId, SearchResult);
+}
+
 void FOnlineSessionPlayFab::OnAppResume(FOnSessionsRemovedDelegate& CompletionDelegate)
 {
 	UE_LOG_ONLINE_SESSION(Verbose, TEXT("FOnlineSessionPlayFab::OnAppResume()"));

--- a/Source/Private/OnlineSessionInterfacePlayFab.h
+++ b/Source/Private/OnlineSessionInterfacePlayFab.h
@@ -286,6 +286,7 @@ public:
 	bool SendSessionInviteToFriend_PlayFabMultiplayer(const PFEntityKey& LocalUserEntityKey, FName SessionName, const PFEntityKey& FriendEntityKey);
 	bool SendSessionInviteToFriends_PlayFabMultiplayer(const PFEntityKey& LocalUserEntityKey, FName SessionName, const TArray<PFEntityKey>& RemoteUserEntityKeys);
 	void OnInvitationReceived_PlayFabMultiplayer(const PFEntityKey& ListeningEntityKey, const PFEntityKey& InvitingEntityKey, const FString& InConnectionString);
+	void NotifyLobbyInviteForStandardDelegate_PlayFabMultiplayer(const PFLobbyInviteReceivedStateChange& StateChange);
 };
 
 typedef TSharedPtr<FOnlineSessionPlayFab, ESPMode::ThreadSafe> FOnlineSessionPlayFabPtr;

--- a/Source/Private/PlayFabLobby.cpp
+++ b/Source/Private/PlayFabLobby.cpp
@@ -1457,6 +1457,7 @@ void FPlayFabLobby::HandleInvitationReceived(const PFLobbyInviteReceivedStateCha
 	if (SessionInterface.IsValid())
 	{
 		SessionInterface->OnInvitationReceived_PlayFabMultiplayer(StateChange.listeningEntity, StateChange.invitingEntity, FString(StateChange.connectionString));
+		SessionInterface->NotifyLobbyInviteForStandardDelegate_PlayFabMultiplayer(StateChange);
 	}
 	else
 	{


### PR DESCRIPTION
Inbound PlayFab lobby invites currently fire only the custom OnPlayFabMultiplayerInviteReceived delegate, so game code wired against the cross-platform IOnlineSession surface (the same path used by EOS, Steam, etc.) never sees them and the existing CreateSearchResultFromInvite helper is unused on non-GDK platforms.

Add NotifyLobbyInviteForStandardDelegate_PlayFabMultiplayer, called alongside the existing OnInvitationReceived_PlayFabMultiplayer in FPlayFabLobby::HandleInvitationReceived. It reuses CreateSearchResultFromInvite and fires TriggerOnSessionUserInviteAcceptedDelegates inline -- the same inline pattern used by OnNativeSessionUserInviteAccepted.