### PR TITLE
Surface the dropped PartyRegionsChangedStateChange::result and errorDetail fields

### DIFF
--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -1370,17 +1370,10 @@ void FOnlineSubsystemPlayFab::OnRegionsChanged(const PartyStateChange* Change)
 	UE_LOG_ONLINE(Verbose, TEXT("FOnlineSubsystemPlayFab::OnRegionsChanged"));
 
 	const PartyRegionsChangedStateChange* Result = static_cast<const PartyRegionsChangedStateChange*>(Change);
-	if (Result)
+	if (Result && Result->result != PartyStateChangeResult::Succeeded)
 	{
-		if (Result->result == PartyStateChangeResult::Succeeded)
-		{
-			UE_LOG_ONLINE(Verbose, TEXT("OnRegionsChanged: SUCCESS"));
-		}
-		else
-		{
-			UE_LOG_ONLINE(Warning, TEXT("OnRegionsChanged: FAIL: %s"), *PartyStateChangeResultToReasonString(Result->result));
-			UE_LOG_ONLINE(Warning, TEXT("ErrorDetail: %s"), *GetPartyErrorMessage(Result->errorDetail));
-		}
+		UE_LOG_ONLINE(Warning, TEXT("OnRegionsChanged: FAIL: %s"), *PartyStateChangeResultToReasonString(Result->result));
+		UE_LOG_ONLINE(Warning, TEXT("ErrorDetail: %s"), *GetPartyErrorMessage(Result->errorDetail));
 	}
 }
 

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -1368,6 +1368,20 @@ void FOnlineSubsystemPlayFab::OnEndpointPropertiesChanged(const PartyStateChange
 void FOnlineSubsystemPlayFab::OnRegionsChanged(const PartyStateChange* Change)
 {
 	UE_LOG_ONLINE(Verbose, TEXT("FOnlineSubsystemPlayFab::OnRegionsChanged"));
+
+	const PartyRegionsChangedStateChange* Result = static_cast<const PartyRegionsChangedStateChange*>(Change);
+	if (Result)
+	{
+		if (Result->result == PartyStateChangeResult::Succeeded)
+		{
+			UE_LOG_ONLINE(Verbose, TEXT("OnRegionsChanged: SUCCESS"));
+		}
+		else
+		{
+			UE_LOG_ONLINE(Warning, TEXT("OnRegionsChanged: FAIL: %s"), *PartyStateChangeResultToReasonString(Result->result));
+			UE_LOG_ONLINE(Warning, TEXT("ErrorDetail: %s"), *GetPartyErrorMessage(Result->errorDetail));
+		}
+	}
 }
 
 void FOnlineSubsystemPlayFab::OnDestroyLocalUserCompleted(const PartyStateChange* Change)

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -721,6 +721,11 @@ bool FOnlineSubsystemPlayFab::CreateAndConnectToPlayFabPartyNetwork()
 
 	PartyNetworkDescriptor NewNetworkDescriptor = {};
 
+	uint32_t CachedRegionCount = 0;
+	const PartyRegion* CachedRegions = nullptr;
+	PartyManager::GetSingleton().GetRegions(&CachedRegionCount, &CachedRegions);
+	UE_LOG_ONLINE(Verbose, TEXT("CreateAndConnectToPlayFabPartyNetwork: CachedRegionCount: %u"), CachedRegionCount);
+
 	// Create a new network descriptor
 	PartyError Err = PartyManager::GetSingleton().CreateNewNetwork(
 		FirstPartyLocalUser,		// Local User
@@ -775,6 +780,8 @@ bool FOnlineSubsystemPlayFab::ConnectToPlayFabPartyNetwork(const FString& NewNet
 	}
 
 	PartyNetworkDescriptor NewNetworkDescriptor = {};
+
+	UE_LOG_ONLINE(Verbose, TEXT("ConnectToPlayFabPartyNetwork: NetworkId: %s"), *NewNetworkId);
 
 	// Deserialize the remote network's descriptor
 	PartyError Err = PartyManager::DeserializeNetworkDescriptor(TCHAR_TO_UTF8(*NewNetworkDescriptorStr), &NewNetworkDescriptor);


### PR DESCRIPTION
The diagnostic disambiguates between region failure and other Party errors that happen to surface the same user-facing string. 

CreateAndConnectToPlayFabPartyNetwork calls PartyManager::CreateNewNetwork(…, 0, nullptr, …), which makes the SDK fall back to whatever PartyManager::GetRegions() has. If background QoS/region discovery fails, GetRegions() is empty and CreateNewNetworkCompleted reports "the region list couldn't be determined" with no upstream cause. This change exposes the actual reason (e.g. InternetConnectivityError, PartyServiceError, FailedToBindToLocalUdpSocket, etc.) so the failure is diagnosable from logs — useful for any developer hitting this on Azure VMs or other restricted-net

Diagnostic-only. 