### PR TITLE
Fix log severity: LocalChatUser nullptr is Verbose not Error on GDK

### DIFF
--- a/Source/PlatformSpecific/ChatPermissionTracking.GDK.cpp
+++ b/Source/PlatformSpecific/ChatPermissionTracking.GDK.cpp
@@ -118,7 +118,7 @@ namespace
 		}
 		else
 		{
-			UE_LOG_ONLINE(Error, TEXT("LocalChatUser is nullptr"));
+			UE_LOG_ONLINE(Verbose, TEXT("LocalChatUser is nullptr"));
 		}
 		return false;
 	}


### PR DESCRIPTION
Matches ChatPermissionTracking.Win.cpp which logs the same condition at Verbose. LocalChatUser being null during
Logging it at Error caused 30Hz spam in logs

Unreal only prints above the currently enabled log level. So that's why we see spam.