### PR TITLE
Guard voice interface when PlayFab voice is disabled

### DIFF
--- a/Source/PlatformSpecific/ChatPermissionTracking.GDK.cpp
+++ b/Source/PlatformSpecific/ChatPermissionTracking.GDK.cpp
@@ -132,6 +132,11 @@ void FOnlineVoicePlayFab::AddTalkerIdMapping(const FString& EntityId, const FStr
 
 void FOnlineVoicePlayFab::SetTalkerCrossNetworkPermission(ECrossNetworkType VoiceChatType, const FString& RemoteUserId, const FString& PlatformModel)
 {
+	if (!bVoiceEnabled)
+	{
+		return;
+	}
+
 	FCrossNetworkTalkerPlayFab CrossNetwork = {VoiceChatType, RemoteUserId, PlatformModel};
 	CrossNetworkTalkers.Emplace(CrossNetwork);
 }

--- a/Source/PlatformSpecific/ChatPermissionTracking.Win.cpp
+++ b/Source/PlatformSpecific/ChatPermissionTracking.Win.cpp
@@ -84,6 +84,11 @@ void FOnlineVoicePlayFab::AddTalkerIdMapping(const FString& EntityId, const FStr
 
 void FOnlineVoicePlayFab::SetTalkerCrossNetworkPermission(ECrossNetworkType VoiceChatType, const FString& RemoteUserId, const FString& PlatformModel)
 {
+	if (!bVoiceEnabled)
+	{
+		return;
+	}
+
 	FCrossNetworkTalkerPlayFab CrossNetwork = {VoiceChatType, RemoteUserId, PlatformModel};
 	CrossNetworkTalkers.Emplace(CrossNetwork);
 }

--- a/Source/Private/OnlineVoiceInterfacePlayFab.cpp
+++ b/Source/Private/OnlineVoiceInterfacePlayFab.cpp
@@ -9,7 +9,11 @@
 FOnlineVoicePlayFab::FOnlineVoicePlayFab(class FOnlineSubsystemPlayFab* InSubsystem) :
 	OSSPlayFab(InSubsystem)
 {
-
+	GConfig->GetBool(TEXT("OnlineSubsystemPlayFab"), TEXT("bHasPlayFabVoiceEnabled"), bVoiceEnabled, GEngineIni);
+	if (!bVoiceEnabled)
+	{
+		UE_LOG_ONLINE_VOICE(Log, TEXT("Voice Chat is Disabled"));
+	}
 }
 
 FOnlineVoicePlayFab::~FOnlineVoicePlayFab()
@@ -111,6 +115,11 @@ void FOnlineVoicePlayFab::StopNetworkedVoice(uint8 LocalUserNum)
 
 bool FOnlineVoicePlayFab::RegisterLocalTalker(uint32 LocalUserNum)
 {
+	if (!bVoiceEnabled)
+	{
+		return true;
+	}
+
 	IOnlineIdentityPtr IdentityIntPtr = OSSPlayFab->GetIdentityInterface();
 	if (IdentityIntPtr.IsValid())
 	{
@@ -134,6 +143,11 @@ bool FOnlineVoicePlayFab::RegisterLocalTalker(uint32 LocalUserNum)
 
 bool FOnlineVoicePlayFab::RegisterLocalTalker(const FUniqueNetId& LocalPlayer)
 {
+	if (!bVoiceEnabled)
+	{
+		return true;
+	}
+
 	IOnlineIdentityPtr IdentityIntPtr = OSSPlayFab->GetIdentityInterface();
 	if (IdentityIntPtr.IsValid())
 	{
@@ -148,6 +162,11 @@ bool FOnlineVoicePlayFab::RegisterLocalTalker(const FUniqueNetId& LocalPlayer)
 
 bool FOnlineVoicePlayFab::RegisterLocalTalker(TSharedPtr<FPlayFabUser> LocalPlayer)
 {
+	if (!bVoiceEnabled)
+	{
+		return true;
+	}
+
 	if (LocalPlayer == nullptr)
 	{
 		return false;
@@ -361,6 +380,11 @@ void FOnlineVoicePlayFab::UnregisterLocalTalkers()
 
 bool FOnlineVoicePlayFab::RegisterRemoteTalker(const FUniqueNetId& UniqueId)
 {
+	if (!bVoiceEnabled)
+	{
+		return true;
+	}
+
 	StartTrackingPermissionForTalker(UniqueId.ToString(), true);
 	return true;
 }
@@ -657,6 +681,11 @@ void FOnlineVoicePlayFab::ProcessTalkingDelegates(float DeltaTime)
 
 void FOnlineVoicePlayFab::Tick(float DeltaTime)
 {
+	if (!bVoiceEnabled)
+	{
+		return;
+	}
+
 	TickTalkerPermissionTracking();
 	ProcessTalkingDelegates(DeltaTime);
 }

--- a/Source/Public/OnlineVoiceInterfacePlayFab.h
+++ b/Source/Public/OnlineVoiceInterfacePlayFab.h
@@ -197,6 +197,7 @@ protected:
 	void StopTrackingPermissionForTalker(const FString& UserId);
 	void TickTalkerPermissionTracking();
 	void OnChatPermissionsChanged(const FString& LocalUserId, const FString& RemoteUserId, PartyChatPermissionOptions perms);
+	bool IsVoiceEnabled() const { return bVoiceEnabled; }
 
 private:
 #if OSS_PLAYFAB_VERBOSE_VOIP_LOGGING
@@ -206,6 +207,7 @@ private:
 	void ProcessTalkingDelegates(float DeltaTime);
 
 	float VoiceNotificationDelta = 0.2f;
+	bool bVoiceEnabled = true;
 
 	FString LocalChatControlLanguage;
 	TMap<FString, FLocalTalkerPlayFab> LocalTalkers;


### PR DESCRIPTION
Honor bHasPlayFabVoiceEnabled at runtime inside FOnlineVoicePlayFab so disabled voice behaves as a no-op.

This prevents per-frame permission tracking and cross-network permission queueing from running when voice is disabled, avoiding LocalChatUser nullptr spam on non-voice titles.