### PR TITLE
Fix: Destroy completion is currently gated only by lobby leave, not party-network leave.

### DIFF
--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -445,6 +445,17 @@ bool FOnlineSessionPlayFab::EndSession(FName SessionName)
 bool FOnlineSessionPlayFab::DestroySession(FName SessionName, const FOnDestroySessionCompleteDelegate& CompletionDelegate /*= FOnDestroySessionCompleteDelegate()*/)
 {
 	UE_LOG_ONLINE_SESSION(Verbose, TEXT("FOnlineSessionPlayFab::DestroySession: SessionName:%s"), *SessionName.ToString());
+	if (bPendingDestroySession)
+	{
+		UE_LOG_ONLINE_SESSION(Warning, TEXT("FOnlineSessionPlayFab::DestroySession: A destroy operation is already in progress for session (%s)"), *PendingDestroySessionName.ToString());
+		OSSPlayFab->ExecuteNextTick([this, SessionName, CompletionDelegate]()
+		{
+			CompletionDelegate.ExecuteIfBound(SessionName, false);
+			TriggerOnDestroySessionCompleteDelegates(SessionName, false);
+		});
+		return false;
+	}
+
 	const bool bPartyLeaveRequired = OSSPlayFab && OSSPlayFab->Network && OSSPlayFab->NetworkState != EPlayFabPartyNetworkState::NoNetwork;
 
 	bPendingDestroySession = true;

--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -472,6 +472,17 @@ bool FOnlineSessionPlayFab::DestroySession(FName SessionName, const FOnDestroySe
 
 	// Leave the PlayFab Party network
 	OSSPlayFab->LeavePlayFabPartyNetwork();
+	if (bPartyLeaveRequired && !OSSPlayFab->bLeavePlayFabPartyNetworkPending)
+	{
+		UE_LOG_ONLINE_SESSION(Warning, TEXT("FOnlineSessionPlayFab::DestroySession: Party leave was required but no pending leave request was recorded; treating party-leave gate as complete."));
+		if (OnLeavePlayFabPartyNetworkCompletedHandle.IsValid())
+		{
+			OSSPlayFab->ClearOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(OnLeavePlayFabPartyNetworkCompletedHandle);
+			OnLeavePlayFabPartyNetworkCompletedHandle.Reset();
+		}
+		bPendingDestroyPartyLeaveComplete = true;
+		bPendingDestroyPartyLeaveResult = (OSSPlayFab->NetworkState == EPlayFabPartyNetworkState::NoNetwork || OSSPlayFab->Network == nullptr);
+	}
 
 	FNamedOnlineSessionPtr Session = GetNamedSessionPtr(SessionName);
 	if (!Session.IsValid())

--- a/Source/Private/OnlineSessionInterfacePlayFab.cpp
+++ b/Source/Private/OnlineSessionInterfacePlayFab.cpp
@@ -41,6 +41,11 @@ FOnlineSessionPlayFab::~FOnlineSessionPlayFab()
 
 	// Clean up delegates
 	OSSPlayFab->ClearOnConnectToPlayFabPartyNetworkCompletedDelegates(this);
+	if (OnLeavePlayFabPartyNetworkCompletedHandle.IsValid())
+	{
+		OSSPlayFab->ClearOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(OnLeavePlayFabPartyNetworkCompletedHandle);
+		OnLeavePlayFabPartyNetworkCompletedHandle.Reset();
+	}
 	ClearOnMatchmakingCompleteDelegate_Handle(OnMatchmakingCompleteDelegateHandle);
 	UnregisterForUpdates();
 }
@@ -440,6 +445,21 @@ bool FOnlineSessionPlayFab::EndSession(FName SessionName)
 bool FOnlineSessionPlayFab::DestroySession(FName SessionName, const FOnDestroySessionCompleteDelegate& CompletionDelegate /*= FOnDestroySessionCompleteDelegate()*/)
 {
 	UE_LOG_ONLINE_SESSION(Verbose, TEXT("FOnlineSessionPlayFab::DestroySession: SessionName:%s"), *SessionName.ToString());
+	const bool bPartyLeaveRequired = OSSPlayFab && OSSPlayFab->Network && OSSPlayFab->NetworkState != EPlayFabPartyNetworkState::NoNetwork;
+
+	bPendingDestroySession = true;
+	PendingDestroySessionName = SessionName;
+	PendingDestroySessionCompletionDelegate = CompletionDelegate;
+	bPendingDestroyLobbyComplete = false;
+	bPendingDestroyLobbyResult = false;
+	bPendingDestroyPartyLeaveComplete = !bPartyLeaveRequired;
+	bPendingDestroyPartyLeaveResult = !bPartyLeaveRequired;
+
+	if (bPartyLeaveRequired)
+	{
+		OnLeavePlayFabPartyNetworkCompletedHandle = OSSPlayFab->AddOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(
+			FOnLeavePlayFabPartyNetworkCompletedDelegate::CreateRaw(this, &FOnlineSessionPlayFab::OnLeavePlayFabPartyNetworkCompleted));
+	}
 
 	if (bUsesNativeSession)
 	{
@@ -457,6 +477,12 @@ bool FOnlineSessionPlayFab::DestroySession(FName SessionName, const FOnDestroySe
 	if (!Session.IsValid())
 	{
 		UE_LOG_ONLINE_SESSION(Warning, TEXT("FOnlineSessionPlayFab::DestroySession: Can't destroy a null online session (%s)"), *SessionName.ToString());
+		if (OnLeavePlayFabPartyNetworkCompletedHandle.IsValid())
+		{
+			OSSPlayFab->ClearOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(OnLeavePlayFabPartyNetworkCompletedHandle);
+			OnLeavePlayFabPartyNetworkCompletedHandle.Reset();
+		}
+		bPendingDestroySession = false;
 		OSSPlayFab->ExecuteNextTick([this, SessionName, CompletionDelegate]()
 		{
 			CompletionDelegate.ExecuteIfBound(SessionName, false);
@@ -468,6 +494,12 @@ bool FOnlineSessionPlayFab::DestroySession(FName SessionName, const FOnDestroySe
 	if (Session->SessionState == EOnlineSessionState::Destroying)
 	{
 		UE_LOG_ONLINE_SESSION(Warning, TEXT("FOnlineSessionPlayFab::DestroySession: Already in process of destroying session (%s)"), *SessionName.ToString());
+		if (OnLeavePlayFabPartyNetworkCompletedHandle.IsValid())
+		{
+			OSSPlayFab->ClearOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(OnLeavePlayFabPartyNetworkCompletedHandle);
+			OnLeavePlayFabPartyNetworkCompletedHandle.Reset();
+		}
+		bPendingDestroySession = false;
 		OSSPlayFab->ExecuteNextTick([this, SessionName, CompletionDelegate]()
 		{
 			CompletionDelegate.ExecuteIfBound(SessionName, false);
@@ -485,6 +517,12 @@ bool FOnlineSessionPlayFab::DestroySession(FName SessionName, const FOnDestroySe
 	{
 		UE_LOG_ONLINE_SESSION(Warning, TEXT("FOnlineSessionPlayFab::DestroySession: Failed to destroy the session %s"), *SessionName.ToString());
 		OSSPlayFab->GetPlayFabLobbyInterface()->ClearOnLeaveLobbyCompletedDelegate_Handle(OnLeaveLobbyCompletedHandle);
+		if (OnLeavePlayFabPartyNetworkCompletedHandle.IsValid())
+		{
+			OSSPlayFab->ClearOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(OnLeavePlayFabPartyNetworkCompletedHandle);
+			OnLeavePlayFabPartyNetworkCompletedHandle.Reset();
+		}
+		bPendingDestroySession = false;
 
 		OSSPlayFab->ExecuteNextTick([this, SessionName, CompletionDelegate]()
 			{
@@ -502,7 +540,59 @@ void FOnlineSessionPlayFab::OnLeaveLobbyCompleted(FName SessionName, bool bSucce
 	UE_LOG_ONLINE_SESSION(Verbose, TEXT("FOnlineSessionPlayFab::OnLeaveLobbyCompleted()"));
 
 	OSSPlayFab->GetPlayFabLobbyInterface()->ClearOnLeaveLobbyCompletedDelegate_Handle(OnLeaveLobbyCompletedHandle);
+
+	if (bPendingDestroySession)
+	{
+		bPendingDestroyLobbyComplete = true;
+		bPendingDestroyLobbyResult = bSuccess;
+		TryCompletePendingDestroySession();
+		return;
+	}
+
 	TriggerOnDestroySessionCompleteDelegates(SessionName, bSuccess);
+}
+
+void FOnlineSessionPlayFab::OnLeavePlayFabPartyNetworkCompleted(bool bSuccess)
+{
+	UE_LOG_ONLINE_SESSION(Verbose, TEXT("FOnlineSessionPlayFab::OnLeavePlayFabPartyNetworkCompleted: bSuccess=%d"), bSuccess);
+
+	if (OnLeavePlayFabPartyNetworkCompletedHandle.IsValid())
+	{
+		OSSPlayFab->ClearOnLeavePlayFabPartyNetworkCompletedDelegate_Handle(OnLeavePlayFabPartyNetworkCompletedHandle);
+		OnLeavePlayFabPartyNetworkCompletedHandle.Reset();
+	}
+
+	bPendingDestroyPartyLeaveComplete = true;
+	bPendingDestroyPartyLeaveResult = bSuccess;
+	TryCompletePendingDestroySession();
+}
+
+void FOnlineSessionPlayFab::TryCompletePendingDestroySession()
+{
+	if (!bPendingDestroySession)
+	{
+		return;
+	}
+
+	if (!bPendingDestroyLobbyComplete || !bPendingDestroyPartyLeaveComplete)
+	{
+		return;
+	}
+
+	const FName CompletedSessionName = PendingDestroySessionName;
+	const bool bSuccess = bPendingDestroyLobbyResult && bPendingDestroyPartyLeaveResult;
+	const FOnDestroySessionCompleteDelegate CompletionDelegate = PendingDestroySessionCompletionDelegate;
+
+	bPendingDestroySession = false;
+	PendingDestroySessionName = NAME_None;
+	PendingDestroySessionCompletionDelegate = FOnDestroySessionCompleteDelegate();
+	bPendingDestroyLobbyComplete = false;
+	bPendingDestroyLobbyResult = false;
+	bPendingDestroyPartyLeaveComplete = true;
+	bPendingDestroyPartyLeaveResult = true;
+
+	CompletionDelegate.ExecuteIfBound(CompletedSessionName, bSuccess);
+	TriggerOnDestroySessionCompleteDelegates(CompletedSessionName, bSuccess);
 }
 
 void FOnlineSessionPlayFab::OnFindLobbiesCompleted(int32 LocalUserNum, bool bSuccess, TSharedPtr<FOnlineSessionSearch> SearchResults)

--- a/Source/Private/OnlineSessionInterfacePlayFab.h
+++ b/Source/Private/OnlineSessionInterfacePlayFab.h
@@ -200,7 +200,17 @@ public:
 	FDelegateHandle OnCancelMatchmakingCompleteHandle;
 
 	void OnLeaveLobbyCompleted(FName SessionName, bool bSuccess);
+	void OnLeavePlayFabPartyNetworkCompleted(bool bSuccess);
+	void TryCompletePendingDestroySession();
 	FDelegateHandle OnLeaveLobbyCompletedHandle;
+	FDelegateHandle OnLeavePlayFabPartyNetworkCompletedHandle;
+	FOnDestroySessionCompleteDelegate PendingDestroySessionCompletionDelegate;
+	FName PendingDestroySessionName;
+	bool bPendingDestroySession = false;
+	bool bPendingDestroyLobbyComplete = false;
+	bool bPendingDestroyLobbyResult = false;
+	bool bPendingDestroyPartyLeaveComplete = true;
+	bool bPendingDestroyPartyLeaveResult = true;
 
 	void OnFindLobbiesCompleted(int32 LocalUserNum, bool bSuccess, TSharedPtr<FOnlineSessionSearch> SearchResults);
 	FOnFindLobbiesCompletedDelegate OnFindLobbiesCompletedDelegateHandle;

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -880,6 +880,7 @@ void FOnlineSubsystemPlayFab::LeavePlayFabPartyNetwork()
 
 	if (NetworkState != EPlayFabPartyNetworkState::LeavingNetwork && Network)
 	{
+		bLeavePlayFabPartyNetworkPending = true;
 		NetworkState = EPlayFabPartyNetworkState::LeavingNetwork;
 		Network->LeaveNetwork(nullptr);
 
@@ -1107,12 +1108,24 @@ void FOnlineSubsystemPlayFab::OnLeaveNetworkCompleted(const PartyStateChange* Ch
 
 				NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 				Network = nullptr;
+
+				if (bLeavePlayFabPartyNetworkPending)
+				{
+					bLeavePlayFabPartyNetworkPending = false;
+					TriggerOnLeavePlayFabPartyNetworkCompletedDelegates(true);
+				}
 			}
 		}
 		else
 		{
 			UE_LOG_ONLINE(Warning, TEXT("OnLeaveNetworkCompleted: FAIL:  %s"), *PartyStateChangeResultToReasonString(Result->result));
 			UE_LOG_ONLINE(Warning, TEXT("ErrorDetail: %s"), *GetPartyErrorMessage(Result->errorDetail));
+
+			if (bLeavePlayFabPartyNetworkPending)
+			{
+				bLeavePlayFabPartyNetworkPending = false;
+				TriggerOnLeavePlayFabPartyNetworkCompletedDelegates(false);
+			}
 		}
 	}
 }
@@ -1125,6 +1138,13 @@ void FOnlineSubsystemPlayFab::OnNetworkDestroyed(const PartyStateChange* Change)
 	if (Result)
 	{
 		UE_LOG_ONLINE(Warning, TEXT("FOnlineSubsystemPlayFab::OnNetworkDestroyed: PlayFab Party network was destroyed with reason code %d"), Result->reason);
+
+		const bool bWasLeaveRequest = Result->reason == PartyDestroyedReason::Requested;
+		if (bLeavePlayFabPartyNetworkPending)
+		{
+			bLeavePlayFabPartyNetworkPending = false;
+			TriggerOnLeavePlayFabPartyNetworkCompletedDelegates(bWasLeaveRequest);
+		}
 
 		NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 		Network = nullptr;

--- a/Source/Public/OnlineSubsystemPlayFab.h
+++ b/Source/Public/OnlineSubsystemPlayFab.h
@@ -42,6 +42,9 @@ typedef FOnEndpointMessageReceived::FDelegate FOnEndpointMessageReceivedDelegate
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnConnectToPlayFabPartyNetworkCompleted, bool /*bSuccess*/);
 typedef FOnConnectToPlayFabPartyNetworkCompleted::FDelegate FOnConnectToPlayFabPartyNetworkCompletedDelegate;
 
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnLeavePlayFabPartyNetworkCompleted, bool /*bSuccess*/);
+typedef FOnLeavePlayFabPartyNetworkCompleted::FDelegate FOnLeavePlayFabPartyNetworkCompletedDelegate;
+
 DECLARE_MULTICAST_DELEGATE_ThreeParams(FOnPartyEndpointCreated, bool /*bSuccess*/, uint16 /*EndpointID*/, bool /*bIsHosting*/);
 typedef FOnPartyEndpointCreated::FDelegate FOnPartyEndpointCreatedDelegate;
 
@@ -178,6 +181,7 @@ public:
 	PartyNetwork* Network = nullptr;
 	PartyLocalEndpoint* LocalEndpoint = nullptr;
 	TMap<uint32, PartyEndpoint*> Endpoints;
+	bool bLeavePlayFabPartyNetworkPending = false;
 	
 	FString NetworkId;
 	PartyNetworkDescriptor NetworkDescriptor;
@@ -284,6 +288,7 @@ public:
 
 	DEFINE_ONLINE_DELEGATE_ONE_PARAM(OnEndpointMessageReceived, const PartyEndpointMessageReceivedStateChange* /*Change*/);
 	DEFINE_ONLINE_DELEGATE_ONE_PARAM(OnConnectToPlayFabPartyNetworkCompleted, bool /*bSuccess*/);
+	DEFINE_ONLINE_DELEGATE_ONE_PARAM(OnLeavePlayFabPartyNetworkCompleted, bool /*bSuccess*/);
 	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnPartyEndpointCreated, bool /*bSuccess*/, uint16 /*EndpointID*/, bool /*bIsHosting*/);
 	
 	PartyEndpoint* GetPartyEndpoint(uint32 EndpointId);


### PR DESCRIPTION
Session teardown is effectively a two-resource operation (Lobby + Party).
Previously, DestroySession completion was driven by lobby leave only. Because Party leave is asynchronous, OnDestroySessionComplete could fire before Party teardown actually finished. That created a race where subsequent Create/Join calls could fail due to lingering Party network state.
The fix gates destroy completion on both lobby leave and Party leave completion (when Party is active), so completion now reflects true teardown completion.

Update:
There was a deadlock risk whereDestroySession could wait forever for a Party-leave completion callback if the subsystem didn’t actually mark a leave as pending (for example, when already transitioning state). The fix adds a guard right after LeavePlayFabPartyNetwork() to detect that case, clear the leave delegate, and mark the party-leave gate complete immediately so TryCompletePendingDestroySession() can still finish.

Another issue was a second DestroySession call could overwrite Boolean pending state, so that second call needs to fail

This should probably be discussed 