### PR TITLE
Fix: Route inbound Party endpoint messages to the correct socket during reconnect

### DIFF
--- a/Source/Private/PlayFabNetDriver.cpp
+++ b/Source/Private/PlayFabNetDriver.cpp
@@ -48,6 +48,7 @@ bool UPlayFabNetDriver::InitBase(bool bInitAsClient, FNetworkNotify* InNotify, c
 		if (FPlayFabSocketSubsystem* SocketSubsystem = GetPlayFabSocketSubsystem())
 		{
 			FUniqueSocket NewSocket = CreateSocketForProtocol(FNetworkProtocolTypes::PlayFab);
+			PlayFabSocket = static_cast<FPlayFabSocket*>(NewSocket.Get());
 
 			SetSocketAndLocalAddress(TSharedPtr<FSocket>(NewSocket.Release(), FSocketDeleter(GetSocketSubsystem())));
 
@@ -87,6 +88,7 @@ bool UPlayFabNetDriver::InitConnect(FNetworkNotify* InNotify, const FURL& InConn
 void UPlayFabNetDriver::Shutdown()
 {
 	UE_LOG(LogSockets, Verbose, TEXT("PlayFabNetDriver: Shutdown called on netdriver"));
+	PlayFabSocket = nullptr;
 
 	Super::Shutdown();
 }

--- a/Source/Private/PlayFabSocketSubsystem.cpp
+++ b/Source/Private/PlayFabSocketSubsystem.cpp
@@ -8,7 +8,6 @@
 #include "SocketSubsystemModule.h"
 #include "PlayFabSocketSubsystem.h"
 #include "IPAddressPlayFab.h"
-#include "Misc/ScopeLock.h"
 
 FPlayFabSocketSubsystem* FPlayFabSocketSubsystem::SocketSingleton = nullptr;
 
@@ -221,10 +220,7 @@ const TCHAR* FPlayFabSocketSubsystem::GetSocketAPIName() const
 
 FPlayFabSocket* FPlayFabSocketSubsystem::GetSocket()
 {
-	int32 ActiveSocketCount = 0;
-
-	FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
-	ActiveSocketCount = ActiveSockets.Num();
+	const int32 ActiveSocketCount = ActiveSockets.Num();
 
 	if (UPlayFabNetDriver* LinkedNetDriver = GetLinkedNetDriver())
 	{
@@ -269,12 +265,8 @@ void FPlayFabSocketSubsystem::AddSocket(FPlayFabSocket* NewSocket)
 
 	if (NewSocket)
 	{
-		int32 ActiveSocketCount = 0;
-		{
-			FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
 		ActiveSockets.Add(NewSocket);
-			ActiveSocketCount = ActiveSockets.Num();
-		}
+		const int32 ActiveSocketCount = ActiveSockets.Num();
 		UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::AddSocket: Added Socket=%p ActiveSockets=%d LinkedNetDriver=%p"), NewSocket, ActiveSocketCount, GetLinkedNetDriver());
 	}
 	else
@@ -287,12 +279,8 @@ void FPlayFabSocketSubsystem::RemoveSocket(FPlayFabSocket* Socket)
 {
 	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::RemoveSocket"));
 
-	int32 ActiveSocketCount = 0;
-	{
-		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
 	ActiveSockets.RemoveSingleSwap(Socket);
-		ActiveSocketCount = ActiveSockets.Num();
-	}
+	const int32 ActiveSocketCount = ActiveSockets.Num();
 	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::RemoveSocket: Removed Socket=%p ActiveSockets=%d LinkedNetDriver=%p"), Socket, ActiveSocketCount, GetLinkedNetDriver());
 }
 
@@ -301,29 +289,18 @@ void FPlayFabSocketSubsystem::CleanUpActiveSockets()
 	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::CleanUpActiveSockets"));
 
 	// Clean up sockets
-	TArray<FPlayFabSocket*> TempArray;
-	{
-		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
-		TempArray = ActiveSockets;
-	}
+	TArray<FPlayFabSocket*> TempArray = ActiveSockets;
 	for (int SocketIdx = 0; SocketIdx < TempArray.Num(); SocketIdx++)
 	{
 		DestroySocket(TempArray[SocketIdx]);
 	}
 
-	{
-		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
-		ActiveSockets.Empty();
-	}
+	ActiveSockets.Empty();
 }
 
 void FPlayFabSocketSubsystem::LinkNetDriver(UPlayFabNetDriver* InNetDriver)
 {
-	int32 ActiveSocketCount = 0;
-	{
-		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
-		ActiveSocketCount = ActiveSockets.Num();
-	}
+	const int32 ActiveSocketCount = ActiveSockets.Num();
 	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::LinkNetDriver: OldNetDriver=%p NewNetDriver=%p ActiveSockets=%d"), NetDriver.Get(), InNetDriver, ActiveSocketCount);
 	NetDriver = InNetDriver;
 }

--- a/Source/Private/PlayFabSocketSubsystem.cpp
+++ b/Source/Private/PlayFabSocketSubsystem.cpp
@@ -8,6 +8,7 @@
 #include "SocketSubsystemModule.h"
 #include "PlayFabSocketSubsystem.h"
 #include "IPAddressPlayFab.h"
+#include "Misc/ScopeLock.h"
 
 FPlayFabSocketSubsystem* FPlayFabSocketSubsystem::SocketSingleton = nullptr;
 
@@ -83,7 +84,12 @@ void FPlayFabSocketSubsystem::OnEndpointMessageReceived(const PartyEndpointMessa
 		{
 			if (FPlayFabSocket* Socket = GetSocket())
 			{
+				UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::OnEndpointMessageReceived: Routing endpoint=%u bytes=%d to Socket=%p LinkedNetDriver=%p"), SenderEndpointId, MessagedReceivedChange->messageSize, Socket, GetLinkedNetDriver());
 				Socket->AddNewPendingData(SenderEndpointId, Payload);
+			}
+			else
+			{
+				UE_LOG(LogSockets, Warning, TEXT("FPlayFabSocketSubsystem::OnEndpointMessageReceived: Dropping endpoint=%u bytes=%d; no active socket. LinkedNetDriver=%p"), SenderEndpointId, MessagedReceivedChange->messageSize, GetLinkedNetDriver());
 			}
 		}
 		else
@@ -215,9 +221,29 @@ const TCHAR* FPlayFabSocketSubsystem::GetSocketAPIName() const
 
 FPlayFabSocket* FPlayFabSocketSubsystem::GetSocket()
 {
-	FPlayFabSocket* FoundSocket = nullptr;
-	for (FPlayFabSocket* Socket : ActiveSockets)
+	int32 ActiveSocketCount = 0;
+
+	FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
+	ActiveSocketCount = ActiveSockets.Num();
+
+	if (UPlayFabNetDriver* LinkedNetDriver = GetLinkedNetDriver())
 	{
+		if (FPlayFabSocket* LinkedSocket = LinkedNetDriver->GetPlayFabSocket())
+		{
+			if (ActiveSockets.Contains(LinkedSocket))
+			{
+				UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::GetSocket: Using LinkedNetDriver Socket=%p ActiveSockets=%d LinkedNetDriver=%p"), LinkedSocket, ActiveSocketCount, LinkedNetDriver);
+				return LinkedSocket;
+			}
+
+			UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::GetSocket: LinkedNetDriver Socket=%p not in ActiveSockets. ActiveSockets=%d LinkedNetDriver=%p"), LinkedSocket, ActiveSocketCount, LinkedNetDriver);
+		}
+	}
+
+	FPlayFabSocket* FoundSocket = nullptr;
+	for (int32 SocketIdx = ActiveSockets.Num() - 1; SocketIdx >= 0; --SocketIdx)
+	{
+		FPlayFabSocket* Socket = ActiveSockets[SocketIdx];
 		if (Socket)
 		{
 			FoundSocket = Socket;
@@ -227,7 +253,11 @@ FPlayFabSocket* FPlayFabSocketSubsystem::GetSocket()
 
 	if (FoundSocket == nullptr)
 	{
-		UE_LOG(LogSockets, Warning, TEXT("FPlayFabSocketSubsystem::GetSocket: Cannot get Socket, returning null"));
+		UE_LOG(LogSockets, Warning, TEXT("FPlayFabSocketSubsystem::GetSocket: Cannot get socket, returning null. ActiveSockets=%d LinkedNetDriver=%p"), ActiveSocketCount, GetLinkedNetDriver());
+	}
+	else
+	{
+		UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::GetSocket: Selected Socket=%p ActiveSockets=%d LinkedNetDriver=%p"), FoundSocket, ActiveSocketCount, GetLinkedNetDriver());
 	}
 
 	return FoundSocket;
@@ -239,7 +269,13 @@ void FPlayFabSocketSubsystem::AddSocket(FPlayFabSocket* NewSocket)
 
 	if (NewSocket)
 	{
+		int32 ActiveSocketCount = 0;
+		{
+			FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
 		ActiveSockets.Add(NewSocket);
+			ActiveSocketCount = ActiveSockets.Num();
+		}
+		UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::AddSocket: Added Socket=%p ActiveSockets=%d LinkedNetDriver=%p"), NewSocket, ActiveSocketCount, GetLinkedNetDriver());
 	}
 	else
 	{
@@ -251,7 +287,13 @@ void FPlayFabSocketSubsystem::RemoveSocket(FPlayFabSocket* Socket)
 {
 	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::RemoveSocket"));
 
+	int32 ActiveSocketCount = 0;
+	{
+		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
 	ActiveSockets.RemoveSingleSwap(Socket);
+		ActiveSocketCount = ActiveSockets.Num();
+	}
+	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::RemoveSocket: Removed Socket=%p ActiveSockets=%d LinkedNetDriver=%p"), Socket, ActiveSocketCount, GetLinkedNetDriver());
 }
 
 void FPlayFabSocketSubsystem::CleanUpActiveSockets()
@@ -259,16 +301,29 @@ void FPlayFabSocketSubsystem::CleanUpActiveSockets()
 	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::CleanUpActiveSockets"));
 
 	// Clean up sockets
-	TArray<FPlayFabSocket*> TempArray = ActiveSockets;
+	TArray<FPlayFabSocket*> TempArray;
+	{
+		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
+		TempArray = ActiveSockets;
+	}
 	for (int SocketIdx = 0; SocketIdx < TempArray.Num(); SocketIdx++)
 	{
 		DestroySocket(TempArray[SocketIdx]);
 	}
 
-	ActiveSockets.Empty();
+	{
+		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
+		ActiveSockets.Empty();
+	}
 }
 
 void FPlayFabSocketSubsystem::LinkNetDriver(UPlayFabNetDriver* InNetDriver)
 {
+	int32 ActiveSocketCount = 0;
+	{
+		FScopeLock ActiveSocketsScopeLock(&ActiveSocketsLock);
+		ActiveSocketCount = ActiveSockets.Num();
+	}
+	UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocketSubsystem::LinkNetDriver: OldNetDriver=%p NewNetDriver=%p ActiveSockets=%d"), NetDriver.Get(), InNetDriver, ActiveSocketCount);
 	NetDriver = InNetDriver;
 }

--- a/Source/Public/PlayFabNetDriver.h
+++ b/Source/Public/PlayFabNetDriver.h
@@ -12,6 +12,7 @@
 #include "PlayFabNetDriver.generated.h"
 
 class FNetworkNotify;
+class FPlayFabSocket;
 
 UCLASS(transient, config=Engine)
 class UPlayFabNetDriver : public UIpNetDriver
@@ -32,9 +33,11 @@ public:
 
 	class FOnlineSubsystemPlayFab* GetOnlineSubsystemPlayFab();
 	class FPlayFabSocketSubsystem* GetPlayFabSocketSubsystem();
+	FPlayFabSocket* GetPlayFabSocket() const { return PlayFabSocket; }
 
 private:
 	bool bFallbackToPlatformSocketSubsystem = false;
+	FPlayFabSocket* PlayFabSocket = nullptr;
 
 protected:
 	friend class UPlayFabNetConnection;

--- a/Source/Public/PlayFabSocketSubsystem.h
+++ b/Source/Public/PlayFabSocketSubsystem.h
@@ -12,7 +12,6 @@
 #include "Containers/Array.h"
 #include "UObject/WeakObjectPtr.h"
 #include "SocketTypes.h"
-#include "HAL/CriticalSection.h"
 #include "OnlineSubsystemPlayFabPackage.h"
 namespace Party {
 	struct PartyEndpointMessageReceivedStateChange;
@@ -86,7 +85,6 @@ protected:
 
 	// Active connection bookkeeping
 	TArray<FPlayFabSocket*> ActiveSockets;
-	mutable FCriticalSection ActiveSocketsLock;
 
 	FDelegateHandle OnEndpointMessageReceivedDelegateHandle;
 

--- a/Source/Public/PlayFabSocketSubsystem.h
+++ b/Source/Public/PlayFabSocketSubsystem.h
@@ -12,6 +12,7 @@
 #include "Containers/Array.h"
 #include "UObject/WeakObjectPtr.h"
 #include "SocketTypes.h"
+#include "HAL/CriticalSection.h"
 #include "OnlineSubsystemPlayFabPackage.h"
 namespace Party {
 	struct PartyEndpointMessageReceivedStateChange;
@@ -85,6 +86,7 @@ protected:
 
 	// Active connection bookkeeping
 	TArray<FPlayFabSocket*> ActiveSockets;
+	mutable FCriticalSection ActiveSocketsLock;
 
 	FDelegateHandle OnEndpointMessageReceivedDelegateHandle;
 


### PR DESCRIPTION
FPlayFabSocketSubsystem::GetSocket always returned the first active socket, with no guarantee that it matched the socket owned by the current net driver. This could cause inbound packets to be queued on the wrong socket, silently dropping them from the perspective of the active connection. 

The proposal
GetSocket() now resolves the socket directly from the linked UPlayFabNetDriver, ensuring inbound packets always reach the socket the active net driver is reading from.
Fallback to newest active socket if no linked driver is available.

The net driver stores its exact socket when created.
FPlayFabSocketSubsystem::GetSocket first uses the linked net driver’s socket.
So inbound packets are enqueued on the same socket queue that UE handshake reads from.
