### PR TITLE
Improve PlayFab failure diagnostics (REST, auth, lobby SDK)

### DIFF
--- a/Source/Private/OnlineIdentityInterfacePlayFab.cpp
+++ b/Source/Private/OnlineIdentityInterfacePlayFab.cpp
@@ -636,6 +636,28 @@ void FOnlineIdentityPlayFab::Auth_HttpRequestComplete(FHttpRequestPtr HttpReques
 			TriggerOnAuthenticateUserCompleteDelegates(0, false, PlatformUserIdStr, TEXT("Failed to deserialize response"));
 		}
 	}
+	else
+	{
+		// The auth HTTP request itself failed (non-success code, timeout, or connection error). Without this the failure is invisible to the dev.
+		if (HttpResponse.IsValid())
+		{
+			// Log the correlation info at Error; keep the response body at Verbose in case it echoes sensitive auth details.
+			UE_LOG_ONLINE(Error, TEXT("[FOnlineIdentityPlayFab::Auth_HttpRequestComplete] Authentication request failed for Platform User %s. Url:%s, ResponseCode:%u, RequestId:%s"),
+				*PlatformUserIdStr,
+				*HttpResponse->GetURL(),
+				HttpResponse->GetResponseCode(),
+				*HttpResponse->GetHeader(TEXT("X-RequestId")));
+
+			UE_LOG_ONLINE(Verbose, TEXT("[FOnlineIdentityPlayFab::Auth_HttpRequestComplete] Authentication request failed for Platform User %s, response:%s"),
+				*PlatformUserIdStr,
+				*HttpResponse->GetContentAsString());
+		}
+		else
+		{
+			UE_LOG_ONLINE(Error, TEXT("[FOnlineIdentityPlayFab::Auth_HttpRequestComplete] Authentication request failed for Platform User %s with no valid HTTP response (connection error or timeout)."),
+				*PlatformUserIdStr);
+		}
+	}
 
 	// Remove the in flight data
 	UserAuthRequestsInFlight.Remove(PlatformUserIdStr);

--- a/Source/Private/PlayFabHelpers.cpp
+++ b/Source/Private/PlayFabHelpers.cpp
@@ -146,13 +146,17 @@ bool ParseDataObjectFromPlayFabResponse(
 {
 	if (!HttpResponse.IsValid())
 	{
+		UE_LOG_ONLINE(Error, TEXT("ParseDataObjectFromPlayFabResponse failed: HttpResponse was invalid!"));
 		return false;
 	}
 
 	if (HttpResponse->GetResponseCode() != 200)
 	{
-		const FString ErrorResponseStr = HttpResponse->GetContentAsString();
-		UE_LOG_ONLINE(Error, TEXT("ParseDataObjectFromPlayFabResponse failed with response code %u, response:%s!"), HttpResponse->GetResponseCode(), *ErrorResponseStr);
+		UE_LOG_ONLINE(Error, TEXT("ParseDataObjectFromPlayFabResponse failed. Url:%s, ResponseCode:%u, RequestId:%s, response:%s!"),
+			*HttpResponse->GetURL(),
+			HttpResponse->GetResponseCode(),
+			*HttpResponse->GetHeader(TEXT("X-RequestId")),
+			*HttpResponse->GetContentAsString());
 		return false;
 	}
 

--- a/Source/Private/PlayFabLobby.cpp
+++ b/Source/Private/PlayFabLobby.cpp
@@ -1079,6 +1079,20 @@ void FPlayFabLobby::HandleCreateAndJoinLobbyCompleted(const PFLobbyCreateAndJoin
 
 	FName SessionName = NAME_None;
 
+	if (FAILED(StateChange.result))
+	{
+		// The CreateAndJoinLobby operation itself failed (e.g. RequestRateLimitExceeded). Surface the real reason here;
+		// otherwise the code below calls PFLobbyGetLobbyId on a lobby that was never created and logs the misleading
+		// "still pending asynchronous creation" (0x89236205) instead of the actual error.
+		if (FName* FoundSessionName = LobbySessionMap.Find(StateChange.lobby))
+		{
+			SessionName = *FoundSessionName;
+		}
+		UE_LOG_ONLINE(Error, TEXT("FPlayFabLobby::HandleCreateAndJoinLobbyCompleted failed to create and join lobby. ErrorCode=[0x%08x], Error message:%s"), StateChange.result, *GetMultiplayerErrorMessage(StateChange.result));
+		TriggerOnLobbyCreatedAndJoinCompletedDelegates(false, SessionName);
+		return;
+	}
+
 	if (FName* FoundSessionName = LobbySessionMap.Find(StateChange.lobby))
 	{
 		SessionName = *FoundSessionName;
@@ -1120,12 +1134,12 @@ void FPlayFabLobby::HandleCreateAndJoinLobbyCompleted(const PFLobbyCreateAndJoin
 					}
 					else
 					{
-						UE_LOG_ONLINE(Warning, TEXT("FPlayFabLobby::HandleCreateAndJoinLobbyCompleted: failed to GetConnectionString: 0x%08x"), Hr);
+						UE_LOG_ONLINE(Warning, TEXT("FPlayFabLobby::HandleCreateAndJoinLobbyCompleted: failed to GetConnectionString: 0x%08x, Error message:%s"), Hr, *GetMultiplayerErrorMessage(Hr));
 					}
 				}
 				else
 				{
-					UE_LOG_ONLINE(Warning, TEXT("FPlayFabLobby::HandleCreateAndJoinLobbyCompleted: failed to GetLobbyId: 0x%08x"), Hr);
+					UE_LOG_ONLINE(Warning, TEXT("FPlayFabLobby::HandleCreateAndJoinLobbyCompleted: failed to GetLobbyId: 0x%08x, Error message:%s"), Hr, *GetMultiplayerErrorMessage(Hr));
 				}
 			}
 			else
@@ -1154,7 +1168,7 @@ void FPlayFabLobby::HandleJoinLobbyCompleted(const PFLobbyJoinLobbyCompletedStat
 	FName* SessionName = LobbySessionMap.Find(StateChange.lobby);
 	if (FAILED(StateChange.result))
 	{
-		UE_LOG_ONLINE(Error, TEXT("Failed to join lobby. ErrorCode=[0x%08x]"), StateChange.result);
+		UE_LOG_ONLINE(Error, TEXT("Failed to join lobby. ErrorCode=[0x%08x], Error message:%s"), StateChange.result, *GetMultiplayerErrorMessage(StateChange.result));
 		JoinResult = ConvertMultiplayerErrorToJoinSessionResult(StateChange.result);
 	}
 	else
@@ -1223,7 +1237,7 @@ void FPlayFabLobby::HandleJoinArrangedLobbyCompleted(const PFLobbyJoinArrangedLo
 	FName* SessionName = LobbySessionMap.Find(StateChange.lobby);
 	if (FAILED(StateChange.result))
 	{
-		UE_LOG_ONLINE(Error, TEXT("Failed to join arranged lobby. ErrorCode=[0x%08x]"), StateChange.result);
+		UE_LOG_ONLINE(Error, TEXT("Failed to join arranged lobby. ErrorCode=[0x%08x], Error message:%s"), StateChange.result, *GetMultiplayerErrorMessage(StateChange.result));
 		TriggerOnJoinArrangedLobbyCompletedDelegates(*SessionName, false);
 		return;
 	}
@@ -1408,7 +1422,7 @@ void FPlayFabLobby::HandleFindLobbiesCompleted(const PFLobbyFindLobbiesCompleted
 
 	if (FAILED(StateChange.result))
 	{
-		UE_LOG_ONLINE(Error, TEXT("Failed to find lobbies. ErrorCode=[0x%08x]"), StateChange.result);
+		UE_LOG_ONLINE(Error, TEXT("Failed to find lobbies. ErrorCode=[0x%08x], Error message:%s"), StateChange.result, *GetMultiplayerErrorMessage(StateChange.result));
 		CurrentSessionSearch->SearchState = EOnlineAsyncTaskState::Failed;
 	}
 	else


### PR DESCRIPTION
Added targeted HTTP diagnostics so PlayFab request failures now surface useful details instead of generic parse failures.
Auth_HttpRequestComplete now explicitly handles:
- request transport failure (!bSucceeded / invalid response)
- non-200 HTTP responses
- and logs status + request ID + response body, then triggers auth-failure delegate with that context.

