### PR TITLE
Make Party send-queue timeout configurable via Engine.ini

### DIFF
--- a/Source/Private/PlayFabSocket.cpp
+++ b/Source/Private/PlayFabSocket.cpp
@@ -6,8 +6,6 @@
 #include "PlayFabSocketSubsystem.h"
 #include "OnlineSubsystemPlayFab.h"
 
-const uint32 FPlayFabSocket::SendTimeout = 500;
-
 FPlayFabSocket::FPlayFabSocket(FOnlineSubsystemPlayFab* InOSSPlayFab, const FString& InSocketDescription, const FName& InSocketProtocol) :
 	FSocket(SOCKTYPE_Datagram, InSocketDescription, InSocketProtocol),
 	OSSPlayFab(InOSSPlayFab),
@@ -15,9 +13,14 @@ FPlayFabSocket::FPlayFabSocket(FOnlineSubsystemPlayFab* InOSSPlayFab, const FStr
 	LocalEndpoint(OSSPlayFab->LocalEndpoint),
 	PendingPackets(2048)
 {
+	// Default send-queue timeout (ms) applied to every Party message. Overridable via
+	// [OnlineSubsystemPlayFab] SendMessageTimeoutMs in Engine.ini.
+	int32 SendMessageTimeoutMs = 500;
+	GConfig->GetInt(TEXT("OnlineSubsystemPlayFab"), TEXT("SendMessageTimeoutMs"), SendMessageTimeoutMs, GEngineIni);
+
 	PartyQueueConfiguration.priority = Party::c_maxSendMessageQueuingPriority;
 	PartyQueueConfiguration.identityForCancelFilters = static_cast<uint32>(reinterpret_cast<uintptr_t>(this));
-	PartyQueueConfiguration.timeoutInMilliseconds = SendTimeout;
+	PartyQueueConfiguration.timeoutInMilliseconds = SendMessageTimeoutMs;
 }
 
 FPlayFabSocket::~FPlayFabSocket()

--- a/Source/Private/PlayFabSocket.h
+++ b/Source/Private/PlayFabSocket.h
@@ -26,8 +26,6 @@ struct PartyPacket
 class FPlayFabSocket : public FSocket
 {
 PACKAGE_SCOPE:
-	static const uint32 SendTimeout;
-	
 	class FOnlineSubsystemPlayFab* OSSPlayFab = nullptr;
 	class FPlayFabSocketSubsystem* SocketSubsystem = nullptr;
 	TWeakObjectPtr<UPlayFabNetDriver> NetDriver;


### PR DESCRIPTION
Read [OnlineSubsystemPlayFab] SendMessageTimeoutMs to override the hardcoded 500ms PartySendMessageQueuingConfiguration.timeoutInMilliseconds. Defaults to 500ms when unset, preserving existing behavior. Enables tuning the send-queue deadline without an engine rebuild when diagnosing relay throughput saturation.