### PR TITLE
Add custom multicast data channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ To resolve this issue, follow the steps below:
 
 These updates should resolve the staging conflict for `Party.dll`.
 
+## Custom multicast data channel
+
+The PlayFab net driver can optionally create a second Party endpoint for raw, byte-identical data that a listen server sends to all connected clients in one `SendMessage` call. This side channel is kept separate from Unreal replication traffic.
+
+Enable it consistently on every peer and allow at least two endpoints per device:
+
+```ini
+[OnlineSubsystemPlayFab]
+bEnableCustomDataEndpoint=true
+MaxEndpointsPerDeviceCount=2
+```
+
+Bind the static, single-cast delegates once during game-module startup:
+
+```cpp
+UPlayFabNetDriver::FillCustomMulticastPayloadDelegate.BindStatic(&FillCustomMulticastPayload);
+UPlayFabNetDriver::OnCustomDataReceivedDelegate.BindStatic(&OnCustomDataReceived);
+```
+
+The fill handler receives `UWorld*`, `UNetDriver*`, and an output byte array. It runs once after the listen server's normal `TickFlush` work; returning `true` with a non-empty payload sends it. The receive handler gets the world, net driver, sender PlayFab Entity ID, and payload immediately after normal `TickDispatch` work on the client.
+
 #### UE5.3
 The WinGDK version of UE5.3 is known to have an issue related to HTTP requests. Epic Games has recognized this problem and addressed it in version 5.4. To work around this issue in UE5.3, you can launch your game using the `-UseWinHttpGDK` argument to switch to WinHTTP instead of xCurl.
 

--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -105,6 +105,12 @@ bool FOnlineSubsystemPlayFab::Init()
 	GConfig->GetInt(TEXT("OnlineSubsystemPlayFab"), TEXT("MaxUserCount"), MaxUserCount, GEngineIni);
 	GConfig->GetInt(TEXT("OnlineSubsystemPlayFab"), TEXT("MaxUsersPerDeviceCount"), MaxUsersPerDeviceCount, GEngineIni);
 	GConfig->GetBool(TEXT("OnlineSubsystemPlayFab"), TEXT("bForceAutoLogin"), bForceAutoLogin, GEngineIni);
+	GConfig->GetBool(TEXT("OnlineSubsystemPlayFab"), TEXT("bEnableCustomDataEndpoint"), bEnableCustomDataEndpoint, GEngineIni);
+	if (bEnableCustomDataEndpoint && MaxEndpointsPerDeviceCount < 2)
+	{
+		UE_LOG_ONLINE(Warning, TEXT("Custom multicast data requires at least two Party endpoints per device; increasing MaxEndpointsPerDeviceCount from %d to 2."), MaxEndpointsPerDeviceCount);
+		MaxEndpointsPerDeviceCount = 2;
+	}
 
 	ParseDirectPeerConnectivityOptions();
 
@@ -222,6 +228,8 @@ void FOnlineSubsystemPlayFab::CleanUpPlayFab()
 
 		NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 		Network = nullptr;
+		CustomDataLocalEndpoint = nullptr;
+		CustomDataEndpoints.Empty();
 
 		// This cleans up everything allocated in PartyManager.Initialize() and
 		// should only be used when done with networking
@@ -428,6 +436,8 @@ void FOnlineSubsystemPlayFab::OnAppSuspend()
 
 		NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 		Network = nullptr;
+		CustomDataLocalEndpoint = nullptr;
+		CustomDataEndpoints.Empty();
 
 		// This cleans up everything allocated in PartyManager.Initialize() and
 		// should only be used when done with networking
@@ -871,6 +881,79 @@ bool FOnlineSubsystemPlayFab::InternalConnectToNetwork(PartyLocalUser* PlayFabPa
 		return false;
 	}
 
+	if (bEnableCustomDataEndpoint)
+	{
+		PartyString CustomDataChannelKey = "Channel";
+		PartyString CustomDataChannelValueString = "CustomData";
+		PartyDataBuffer CustomDataChannelValue =
+		{
+			CustomDataChannelValueString,
+			static_cast<uint32_t>(FCStringAnsi::Strlen(CustomDataChannelValueString) + 1)
+		};
+
+		Err = Network->CreateEndpoint(
+			PlayFabPartyLocalUser,
+			1,
+			&CustomDataChannelKey,
+			&CustomDataChannelValue,
+			nullptr,
+			&CustomDataLocalEndpoint
+		);
+
+		if (PARTY_FAILED(Err))
+		{
+			CustomDataLocalEndpoint = nullptr;
+			UE_LOG_ONLINE(Warning, TEXT("FOnlineSubsystemPlayFab::InternalConnectToNetwork: Custom data endpoint creation failed; custom multicast will be unavailable: %s"), *GetPartyErrorMessage(Err));
+		}
+	}
+
+	return true;
+}
+
+bool FOnlineSubsystemPlayFab::MulticastCustomData(const TArray<uint8>& Payload)
+{
+	if (CustomDataLocalEndpoint == nullptr || Payload.Num() == 0)
+	{
+		return false;
+	}
+
+	TArray<PartyEndpoint*> TargetEndpoints;
+	TargetEndpoints.Reserve(CustomDataEndpoints.Num());
+	for (const TPair<uint32, PartyEndpoint*>& Endpoint : CustomDataEndpoints)
+	{
+		if (Endpoint.Value != nullptr)
+		{
+			TargetEndpoints.Add(Endpoint.Value);
+		}
+	}
+
+	if (TargetEndpoints.Num() == 0)
+	{
+		return true;
+	}
+
+	PartySendMessageQueuingConfiguration QueueConfiguration = {};
+	QueueConfiguration.priority = c_maxSendMessageQueuingPriority;
+	QueueConfiguration.identityForCancelFilters = static_cast<uint32>(reinterpret_cast<uintptr_t>(this));
+	QueueConfiguration.timeoutInMilliseconds = 100;
+
+	PartyDataBuffer DataBuffer = { Payload.GetData(), static_cast<uint32_t>(Payload.Num()) };
+	PartyError Err = CustomDataLocalEndpoint->SendMessage(
+		static_cast<uint32_t>(TargetEndpoints.Num()),
+		TargetEndpoints.GetData(),
+		PartySendMessageOptions::AllowLazyAcknowledgement,
+		&QueueConfiguration,
+		1,
+		&DataBuffer,
+		nullptr
+	);
+
+	if (PARTY_FAILED(Err))
+	{
+		UE_LOG_ONLINE(Warning, TEXT("FOnlineSubsystemPlayFab::MulticastCustomData: SendMessage failed: %s"), *GetPartyErrorMessage(Err));
+		return false;
+	}
+
 	return true;
 }
 
@@ -1107,6 +1190,8 @@ void FOnlineSubsystemPlayFab::OnLeaveNetworkCompleted(const PartyStateChange* Ch
 
 				NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 				Network = nullptr;
+				CustomDataLocalEndpoint = nullptr;
+				CustomDataEndpoints.Empty();
 			}
 		}
 		else
@@ -1128,6 +1213,8 @@ void FOnlineSubsystemPlayFab::OnNetworkDestroyed(const PartyStateChange* Change)
 
 		NetworkState = EPlayFabPartyNetworkState::NoNetwork;
 		Network = nullptr;
+		CustomDataLocalEndpoint = nullptr;
+		CustomDataEndpoints.Empty();
 
 		FPlayFabSocketSubsystem* SocketSubsystem = static_cast<FPlayFabSocketSubsystem*>(ISocketSubsystem::Get(PLAYFAB_SOCKET_SUBSYSTEM));
 		if (SocketSubsystem == nullptr)
@@ -1186,7 +1273,24 @@ void FOnlineSubsystemPlayFab::OnEndpointMessageReceived(const PartyStateChange* 
 	const PartyEndpointMessageReceivedStateChange* Result = static_cast<const PartyEndpointMessageReceivedStateChange*>(Change);
 	if (Result)
 	{
-		TriggerOnEndpointMessageReceivedDelegates(Result);
+		bool bCustomDataMessage = false;
+		for (uint32_t EndpointIndex = 0; EndpointIndex < Result->receiverEndpointCount; ++EndpointIndex)
+		{
+			if (Result->receiverEndpoints[EndpointIndex] == CustomDataLocalEndpoint)
+			{
+				bCustomDataMessage = true;
+				break;
+			}
+		}
+
+		if (bCustomDataMessage)
+		{
+			TriggerOnCustomDataMessageReceivedDelegates(Result);
+		}
+		else
+		{
+			TriggerOnEndpointMessageReceivedDelegates(Result);
+		}
 	}
 }
 
@@ -1278,6 +1382,23 @@ void FOnlineSubsystemPlayFab::OnEndpointCreated(const PartyStateChange* Change)
 			}
 			else
 			{
+				PartyDataBuffer ChannelValue = {};
+				PartyError ChannelErr = NewEndpoint->GetSharedProperty("Channel", &ChannelValue);
+				static const ANSICHAR CustomDataChannel[] = "CustomData";
+				if (PARTY_SUCCEEDED(ChannelErr) &&
+					ChannelValue.buffer != nullptr &&
+					ChannelValue.bufferByteCount == sizeof(CustomDataChannel) &&
+					FMemory::Memcmp(ChannelValue.buffer, CustomDataChannel, sizeof(CustomDataChannel)) == 0)
+				{
+					if (NewEndpoint != CustomDataLocalEndpoint)
+					{
+						CustomDataEndpoints.Add(EndpointId, NewEndpoint);
+					}
+
+					UE_LOG(LogNet, Verbose, TEXT("FOnlineSubsystemPlayFab::OnEndpointCreated: Classified custom data endpoint: %d"), EndpointId);
+					return;
+				}
+
 				Endpoints.Add(EndpointId, NewEndpoint);
 				NetworkState = EPlayFabPartyNetworkState::NetworkReady;
 				TriggerOnPartyEndpointCreatedDelegates(true, EndpointId, bIsHosting);
@@ -1303,6 +1424,30 @@ void FOnlineSubsystemPlayFab::OnEndpointDestroyed(const PartyStateChange* Change
 		PartyEndpoint* NewEndpoint = Result->endpoint;
 		if (NewEndpoint)
 		{
+			bool bCustomDataEndpoint = NewEndpoint == CustomDataLocalEndpoint;
+			if (bCustomDataEndpoint)
+			{
+				CustomDataLocalEndpoint = nullptr;
+			}
+			else
+			{
+				for (auto EndpointIt = CustomDataEndpoints.CreateIterator(); EndpointIt; ++EndpointIt)
+				{
+					if (EndpointIt.Value() == NewEndpoint)
+					{
+						EndpointIt.RemoveCurrent();
+						bCustomDataEndpoint = true;
+						break;
+					}
+				}
+			}
+
+			if (bCustomDataEndpoint)
+			{
+				UE_LOG_ONLINE(Verbose, TEXT("FOnlineSubsystemPlayFab::OnEndpointDestroyed: Destroyed custom data endpoint with reason code %d"), Result->reason);
+				return;
+			}
+
 			uint16 EndpointId = 0;
 			PartyError Err = NewEndpoint->GetUniqueIdentifier(&EndpointId);
 			if (PARTY_FAILED(Err) || EndpointId == 0)

--- a/Source/Private/PlayFabNetDriver.cpp
+++ b/Source/Private/PlayFabNetDriver.cpp
@@ -10,6 +10,9 @@
 #include "OnlineSubsystemSessionSettings.h"
 #include "PlayFabSocket.h"
 
+FOnFillCustomMulticastPayload UPlayFabNetDriver::FillCustomMulticastPayloadDelegate;
+FOnCustomDataReceived UPlayFabNetDriver::OnCustomDataReceivedDelegate;
+
 UPlayFabNetDriver::UPlayFabNetDriver(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
@@ -55,6 +58,8 @@ bool UPlayFabNetDriver::InitBase(bool bInitAsClient, FNetworkNotify* InNotify, c
 
 			if (UNetDriver::InitBase(bInitAsClient, InNotify, URL, bReuseAddressAndPort, Error))
 			{
+				OnCustomDataMessageReceivedDelegateHandle = OSSPlayFab->AddOnCustomDataMessageReceivedDelegate_Handle(
+					FOnCustomDataMessageReceivedDelegate::CreateUObject(this, &UPlayFabNetDriver::OnCustomDataMessageReceived));
 				return true;
 			}
 		}
@@ -87,6 +92,14 @@ bool UPlayFabNetDriver::InitConnect(FNetworkNotify* InNotify, const FURL& InConn
 void UPlayFabNetDriver::Shutdown()
 {
 	UE_LOG(LogSockets, Verbose, TEXT("PlayFabNetDriver: Shutdown called on netdriver"));
+	if (OnCustomDataMessageReceivedDelegateHandle.IsValid())
+	{
+		if (FOnlineSubsystemPlayFab* OSSPlayFab = GetOnlineSubsystemPlayFab())
+		{
+			OSSPlayFab->ClearOnCustomDataMessageReceivedDelegate_Handle(OnCustomDataMessageReceivedDelegateHandle);
+		}
+		OnCustomDataMessageReceivedDelegateHandle.Reset();
+	}
 
 	Super::Shutdown();
 }
@@ -94,6 +107,57 @@ void UPlayFabNetDriver::Shutdown()
 void UPlayFabNetDriver::TickDispatch(float DeltaTime)
 {
 	Super::TickDispatch(DeltaTime);
+
+	TPair<FString, TArray<uint8>> CustomDataPacket;
+	while (PendingCustomDataPackets.Dequeue(CustomDataPacket))
+	{
+		OnCustomDataReceivedDelegate.ExecuteIfBound(GetWorld(), this, CustomDataPacket.Key, CustomDataPacket.Value);
+	}
+}
+
+void UPlayFabNetDriver::TickFlush(float DeltaSeconds)
+{
+	Super::TickFlush(DeltaSeconds);
+
+	if (IsServer() && !bFallbackToPlatformSocketSubsystem)
+	{
+		SendCustomMulticastDataForTick();
+	}
+}
+
+void UPlayFabNetDriver::SendCustomMulticastDataForTick()
+{
+	FOnlineSubsystemPlayFab* OSSPlayFab = GetOnlineSubsystemPlayFab();
+	if (OSSPlayFab == nullptr || OSSPlayFab->CustomDataLocalEndpoint == nullptr || !FillCustomMulticastPayloadDelegate.IsBound())
+	{
+		return;
+	}
+
+	TArray<uint8> Payload;
+	if (FillCustomMulticastPayloadDelegate.Execute(GetWorld(), this, Payload) && Payload.Num() > 0)
+	{
+		OSSPlayFab->MulticastCustomData(Payload);
+	}
+}
+
+void UPlayFabNetDriver::OnCustomDataMessageReceived(const Party::PartyEndpointMessageReceivedStateChange* Change)
+{
+	if (Change == nullptr || Change->senderEndpoint == nullptr || Change->messageBuffer == nullptr || Change->messageSize == 0)
+	{
+		return;
+	}
+
+	PartyString SenderEntityId = nullptr;
+	PartyError Err = Change->senderEndpoint->GetEntityId(&SenderEntityId);
+	if (PARTY_FAILED(Err) || SenderEntityId == nullptr)
+	{
+		UE_LOG(LogSockets, Warning, TEXT("UPlayFabNetDriver::OnCustomDataMessageReceived: Failed to resolve sender EntityId: %s"), *GetPartyErrorMessage(Err));
+		return;
+	}
+
+	const uint8* Buffer = static_cast<const uint8*>(Change->messageBuffer);
+	TArray<uint8> Payload(Buffer, Change->messageSize);
+	PendingCustomDataPackets.Enqueue(TPair<FString, TArray<uint8>>(UTF8_TO_TCHAR(SenderEntityId), MoveTemp(Payload)));
 }
 
 FOnlineSubsystemPlayFab* UPlayFabNetDriver::GetOnlineSubsystemPlayFab()

--- a/Source/Private/PlayFabSocket.cpp
+++ b/Source/Private/PlayFabSocket.cpp
@@ -59,9 +59,10 @@ bool FPlayFabSocket::SendTo(const uint8* Data, int32 Count, int32& BytesSent, co
 	PartyEndpoint* RemoteEndpoint = OSSPlayFab->GetPartyEndpoint(EndpointId);
 	if (RemoteEndpoint == nullptr)
 	{
-		// Might be disconnected peer
+		// Endpoint discovery can lag behind JoinSession completion. Let the connection retry on
+		// the next tick; confirmed disconnects are closed by the endpoint/network destroy paths.
 		UE_LOG(LogSockets, Verbose, TEXT("FPlayFabSocket::SendTo failed, no endpoint for %s"), *Destination.ToString(true));
-		SocketSubsystem->LastSocketError = SE_ENOTCONN;
+		SocketSubsystem->LastSocketError = SE_EWOULDBLOCK;
 		return false;
 	}
 

--- a/Source/Public/OnlineSubsystemPlayFab.h
+++ b/Source/Public/OnlineSubsystemPlayFab.h
@@ -39,6 +39,10 @@ typedef TSharedPtr<class FMatchmakingInterfacePlayFab, ESPMode::ThreadSafe> FMat
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnEndpointMessageReceived, const PartyEndpointMessageReceivedStateChange* /*Change*/);
 typedef FOnEndpointMessageReceived::FDelegate FOnEndpointMessageReceivedDelegate;
 
+/** Fired for messages received on the custom multicast data endpoint. */
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnCustomDataMessageReceived, const PartyEndpointMessageReceivedStateChange* /*Change*/);
+typedef FOnCustomDataMessageReceived::FDelegate FOnCustomDataMessageReceivedDelegate;
+
 DECLARE_MULTICAST_DELEGATE_OneParam(FOnConnectToPlayFabPartyNetworkCompleted, bool /*bSuccess*/);
 typedef FOnConnectToPlayFabPartyNetworkCompleted::FDelegate FOnConnectToPlayFabPartyNetworkCompletedDelegate;
 
@@ -165,6 +169,7 @@ public:
 	bool bMultiplayerInitialized = false;
 	bool bMemoryCallbacksSet = false;
 	bool bForceAutoLogin = true;
+	bool bEnableCustomDataEndpoint = false;
 
 	int32 MaxDeviceCount = 8;
 	int32 MaxDevicesPerUserCount = 1;
@@ -178,6 +183,8 @@ public:
 	PartyNetwork* Network = nullptr;
 	PartyLocalEndpoint* LocalEndpoint = nullptr;
 	TMap<uint32, PartyEndpoint*> Endpoints;
+	PartyLocalEndpoint* CustomDataLocalEndpoint = nullptr;
+	TMap<uint32, PartyEndpoint*> CustomDataEndpoints;
 	
 	FString NetworkId;
 	PartyNetworkDescriptor NetworkDescriptor;
@@ -211,6 +218,10 @@ private:
 	void DoWork();
 
 	bool InternalConnectToNetwork(PartyLocalUser* PlayFabPartyLocalUser, const FString& InNetworkId, Party::PartyNetworkDescriptor& NetworkDescriptor);
+
+	/** Sends one payload to all remote custom-data endpoints in one Party call. */
+	bool MulticastCustomData(const TArray<uint8>& Payload);
+	friend class UPlayFabNetDriver;
 
 	FOnlineIdentityPlayFabPtr IdentityInterface;
 	FOnlineSessionPlayFabPtr SessionInterface;
@@ -283,6 +294,7 @@ public:
 	void OnConfigureAudioManipulationRenderStreamCompleted(const PartyStateChange* Change);
 
 	DEFINE_ONLINE_DELEGATE_ONE_PARAM(OnEndpointMessageReceived, const PartyEndpointMessageReceivedStateChange* /*Change*/);
+	DEFINE_ONLINE_DELEGATE_ONE_PARAM(OnCustomDataMessageReceived, const PartyEndpointMessageReceivedStateChange* /*Change*/);
 	DEFINE_ONLINE_DELEGATE_ONE_PARAM(OnConnectToPlayFabPartyNetworkCompleted, bool /*bSuccess*/);
 	DEFINE_ONLINE_DELEGATE_THREE_PARAM(OnPartyEndpointCreated, bool /*bSuccess*/, uint16 /*EndpointID*/, bool /*bIsHosting*/);
 	

--- a/Source/Public/PlayFabNetDriver.h
+++ b/Source/Public/PlayFabNetDriver.h
@@ -9,12 +9,23 @@
 #include "IpNetDriver.h"
 #include "OnlineSubsystemPlayFabPackage.h"
 #include "OnlineSubsystemPlayFabTypes.h"
+#include "Containers/Queue.h"
 #include "PlayFabNetDriver.generated.h"
 
 class FNetworkNotify;
+namespace Party
+{
+	struct PartyEndpointMessageReceivedStateChange;
+}
+
+/** Supplies the byte-identical custom payload sent by a listen server for the current tick. */
+DECLARE_DELEGATE_RetVal_ThreeParams(bool, FOnFillCustomMulticastPayload, UWorld* /*World*/, UNetDriver* /*NetDriver*/, TArray<uint8>& /*OutPayload*/);
+
+/** Receives a custom multicast payload on a client. */
+DECLARE_DELEGATE_FourParams(FOnCustomDataReceived, UWorld* /*World*/, UNetDriver* /*NetDriver*/, const FString& /*SenderEntityId*/, const TArray<uint8>& /*Payload*/);
 
 UCLASS(transient, config=Engine)
-class UPlayFabNetDriver : public UIpNetDriver
+class ONLINESUBSYSTEMPLAYFAB_API UPlayFabNetDriver : public UIpNetDriver
 {
 	GENERATED_UCLASS_BODY()
 
@@ -29,12 +40,24 @@ public:
 	virtual void Shutdown() override;
 	virtual bool IsNetResourceValid() override { return true; }
 	virtual void TickDispatch(float DeltaTime) override;
+	virtual void TickFlush(float DeltaSeconds) override;
+
+	/** Bind once at module startup to provide the listen server's payload for each tick. */
+	static FOnFillCustomMulticastPayload FillCustomMulticastPayloadDelegate;
+
+	/** Bind once at module startup to consume custom multicast payloads on clients. */
+	static FOnCustomDataReceived OnCustomDataReceivedDelegate;
 
 	class FOnlineSubsystemPlayFab* GetOnlineSubsystemPlayFab();
 	class FPlayFabSocketSubsystem* GetPlayFabSocketSubsystem();
 
 private:
 	bool bFallbackToPlatformSocketSubsystem = false;
+
+	void SendCustomMulticastDataForTick();
+	void OnCustomDataMessageReceived(const Party::PartyEndpointMessageReceivedStateChange* Change);
+	FDelegateHandle OnCustomDataMessageReceivedDelegateHandle;
+	TQueue<TPair<FString, TArray<uint8>>> PendingCustomDataPackets;
 
 protected:
 	friend class UPlayFabNetConnection;


### PR DESCRIPTION
How multicast works

- Optionally creates a second tagged Party endpoint dedicated to custom data
- Tracks only remote custom endpoints and sends one payload to all of them through a single Party SendMessage() call: 
- Routes messages received by the custom endpoint away from Unreal’s normal socket/NetConnection parser: 
- Collects and sends one server payload after Super::TickFlush(): 
- Queues received payloads and dispatches them immediately after Super::TickDispatch(): 
- Provides static bind-once delegates on UPlayFabNetDriver: 
- Treats an endpoint not yet discovered during connection startup as transient with SE_EWOULDBLOCK. This used because SE_ENOTCONN represents a hard failure and starts the connection shut down.
- Documents enablement and binding: README.md
- The feature is opt-in through bEnableCustomDataEndpoint