### PR TITLE
Fix CreateSession Hang When Party Endpoint Creation Fails

### DIFF
--- a/Source/Private/OnlineSubsystemPlayFab.cpp
+++ b/Source/Private/OnlineSubsystemPlayFab.cpp
@@ -1247,6 +1247,17 @@ void FOnlineSubsystemPlayFab::OnNetworkPropertiesChanged(const PartyStateChange*
 void FOnlineSubsystemPlayFab::OnCreateEndpointCompleted(const PartyStateChange* Change)
 {
 	UE_LOG_ONLINE(Verbose, TEXT("FOnlineSubsystemPlayFab::OnCreateEndpointCompleted"));
+
+	const PartyCreateEndpointCompletedStateChange* Result = static_cast<const PartyCreateEndpointCompletedStateChange*>(Change);
+	if (Result && Result->result != PartyStateChangeResult::Succeeded)
+	{
+		UE_LOG_ONLINE(Warning, TEXT("CreateEndpointCompleted: FAIL: %s"), *PartyStateChangeResultToReasonString(Result->result));
+		UE_LOG_ONLINE(Warning, TEXT("ErrorDetail: %s"), *GetPartyErrorMessage(Result->errorDetail));
+
+		const bool bIsHosting = NetworkState == EPlayFabPartyNetworkState::JoiningNetwork_Host ||
+			NetworkState == EPlayFabPartyNetworkState::JoiningNetwork_Host_PendingEndpointCreation;
+		TriggerOnPartyEndpointCreatedDelegates(false, 0, bIsHosting);
+	}
 }
 
 void FOnlineSubsystemPlayFab::OnDestroyEndpointCompleted(const PartyStateChange* Change)


### PR DESCRIPTION
Handle asynchronous Party endpoint creation failures by forwarding them through the existing endpoint failure delegate. This ensures pending session operations complete instead of waiting indefinitely for an endpoint-created event that will never arrive.