### PR TITLE
[Workaround] Add configurable PSN auth version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ The WinGDK version of UE5.3 is known to have an issue related to HTTP requests. 
 
 The PlayFab Online Subsystem (PF OSS) v2 is currently generally available (GA) for GDK and Win64+Steam, Nintendo Switch, and Sony PS4™/PS5™.
 
+For PlayStation titles that require an explicit PSN authentication version, set `PsnAuthVersion` to `v2` or `v3` in the game's engine configuration:
+
+```ini
+[OnlineSubsystemPlayFab]
+PsnAuthVersion=v3
+```
+
+When the setting is omitted, the login request does not include `AuthVersion`, preserving the existing automatic-detection behavior.
+
 For platform certification and shipping to retail users, games must use the generally available (GA) release of the SDKs and engine plugins that will become available in the coming months.
 
 For games shipping to Xbox console and PC Game Pass program before September 2022, it is recommended that games use the base Online Subsystem (OSS) for GDK provided by Epic for multiplayer integration (backed by Xbox Live multiplayer services) and the PlayFab Online Subsystem (PF OSS) v1.x for Party networking and VOIP available on the [GDK download website](https://aka.ms/gdkdl).

--- a/Source/Private/OnlineIdentityInterfacePlayFab.cpp
+++ b/Source/Private/OnlineIdentityInterfacePlayFab.cpp
@@ -485,6 +485,22 @@ void FOnlineIdentityPlayFab::FinishRequest(bool bPlatformDataSuccess, const FStr
 			RequestBodyJson->SetBoolField(TEXT("CreateAccount"), true);
 			RequestBodyJson->SetStringField(TEXT("TitleId"), TitleIdStr);
 
+#if defined(OSS_PLAYFAB_PLAYSTATION)
+			FString PsnAuthVersion;
+			if (GConfig->GetString(TEXT("OnlineSubsystemPlayFab"), TEXT("PsnAuthVersion"), PsnAuthVersion, GEngineIni))
+			{
+				PsnAuthVersion.TrimStartAndEndInline();
+				if (PsnAuthVersion.Equals(TEXT("v2"), ESearchCase::IgnoreCase) || PsnAuthVersion.Equals(TEXT("v3"), ESearchCase::IgnoreCase))
+				{
+					RequestBodyJson->SetStringField(TEXT("AuthVersion"), PsnAuthVersion.ToLower());
+				}
+				else
+				{
+					UE_LOG_ONLINE(Error, TEXT("FOnlineIdentityPlayFab::FinishRequest: PsnAuthVersion must be v2 or v3; omitting AuthVersion"));
+				}
+			}
+#endif
+
 			// Serialize request body
 			FString RequestBodySerialized;
 			TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&RequestBodySerialized);


### PR DESCRIPTION
* Adds an optional PsnAuthVersion configuration for PlayStation login.
* Supports v2 and v3 values, case-insensitively.
* Sends the configured value as AuthVersion in LoginWithPSN.
* Preserves existing automatic detection when unset.
* Logs an error and omits AuthVersion for invalid values.
```[OnlineSubsystemPlayFab]
PsnAuthVersion=v3```
